### PR TITLE
Prefill address when entering the interview

### DIFF
--- a/survey/src/admin/serverAdmin.ts
+++ b/survey/src/admin/serverAdmin.ts
@@ -9,15 +9,15 @@ import path from 'path';
 import setupServer from 'evolution-backend/lib/apps/admin';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
+import serverUpdateCallbacks from '../survey/server/serverFieldUpdate';
+import serverValidations from '../survey/server/serverValidations';
 
-// TODO Add server update callbacks, if any
-// TODO Add server validations, if any
 // TODO Add validation list filter if necessary
 
 const configureServer = () => {
     setProjectConfig({
-        serverUpdateCallbacks: [],
-        serverValidations: {}
+        serverUpdateCallbacks,
+        serverValidations
     });
 };
 

--- a/survey/src/server.ts
+++ b/survey/src/server.ts
@@ -9,14 +9,13 @@ import path from 'path';
 import setupServer from 'evolution-backend/lib/apps/participant';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
-
-// TODO Add server update callbacks, if any
-// TODO Add server validations, if any
+import serverUpdateCallbacks from './survey/server/serverFieldUpdate';
+import serverValidations from './survey/server/serverValidations';
 
 const configureServer = () => {
     setProjectConfig({
-        serverUpdateCallbacks: [],
-        serverValidations: {}
+        serverUpdateCallbacks,
+        serverValidations
     });
 };
 

--- a/survey/src/survey/common/__tests__/helper.test.ts
+++ b/survey/src/survey/common/__tests__/helper.test.ts
@@ -1,0 +1,32 @@
+import { formatAccessCode } from '../helper';
+
+describe('helper', () => {
+  describe('formatAccessCode', () => {
+    test.each([
+      // Test case format: [description, input, expected output]
+      ['formats 8 digits as XXXX-XXXX', '12345678', '1234-5678'],
+      ['converts existing dashes correctly', '1234-5678', '1234-5678'],
+      ['converts underscores to dashes', '1234_5678', '1234-5678'],
+      ['removes letters and special characters', 'ab12cd34ef56gh78', '1234-5678'],
+      ['handles mixed special characters', '12_34-ab56!78', '1234-5678'],
+      ['keeps dashes but removes other special chars', '12-34-56-78', '1234-5678'],
+      ['does not format if less than 8 digits', '123456', '123456'],
+      ['truncates to 9 characters max', '1234567890', '1234-5678'],
+      ['handles input with spaces', '1234 5678', '1234-5678'],
+      ['handles input with spaces before and after', '   12 34 5678  ', '1234-5678'],
+      ['handles empty string', '', ''],
+      ['handles empty string', '1234db', '1234'],
+      ['partial access code, 1 character', '1', '1'],
+      ['partial access code, 2 characters', '12', '12'],
+      ['partial access code, 3 characters', '123', '123'],
+      ['partial access code, 4 characters', '1234', '1234'],
+      ['partial access code, 4 characters + dash', '1234-', '1234-'],
+      ['partial access code, 4 characters + dash + 2 characters', '1234-23', '1234-23'],
+      ['partial access code, 5 characters', '12345', '12345'],
+      ['partial access code, 6 characters', '123456', '123456'],
+      ['partial access code, 7 characters', '1234567', '1234567'],
+    ])('%s', (_, input, expected) => {
+      expect(formatAccessCode(input)).toBe(expected);
+    });
+  });
+});

--- a/survey/src/survey/common/helper.ts
+++ b/survey/src/survey/common/helper.ts
@@ -1,0 +1,19 @@
+/**
+ * TODO Move to Evolution as an 8DigitsAccessCodeFormatter
+ * @param input The input to format
+ * @returns The formatted access code
+ */
+export const formatAccessCode = (input: string) => {
+    input = input.replaceAll('_', '-'); // change _ to -
+    input = input.replace(/[^-\d]/g, ''); // Remove everything but numbers and -
+    // Get only the digits
+    const digits = input.replace(/\D+/g, '');
+
+    // If we have at least 8 digits, format the first 8 as access code
+    if (digits.length >= 8) {
+        return digits.slice(0, 4) + '-' + digits.slice(4, 8);
+    }
+
+    // For less than 8 digits, return as is (already cleaned of non-allowed chars)
+    return input.slice(0, 9);
+};

--- a/survey/src/survey/server/__tests__/serverFieldUpdate.test.ts
+++ b/survey/src/survey/server/__tests__/serverFieldUpdate.test.ts
@@ -1,0 +1,135 @@
+
+import updateCallbacks from '../serverFieldUpdate';
+import _cloneDeep from 'lodash/cloneDeep';
+import each from 'jest-each';
+import { getPreFilledResponseByPath } from 'evolution-backend/lib/services/interviews/serverFieldUpdate';
+import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import '../serverValidations'; // Make sure access code format validation is registered
+
+jest.mock('evolution-backend/lib/services/interviews/serverFieldUpdate', () => ({
+    getPreFilledResponseByPath: jest.fn().mockResolvedValue({})
+}));
+const preFilledMock = getPreFilledResponseByPath as jest.MockedFunction<typeof getPreFilledResponseByPath>;
+
+const baseInterview: InterviewAttributes = {
+    response: {
+        household: {
+            size: 1,
+            tripsDate: '2022-09-26',
+            persons: {
+                a12345: {
+                    age: 56,
+                    gender: 'female',
+                    occupation: 'fullTimeStudent',
+                    visitedPlaces: {
+                        p1: {
+                            geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.1, 45.1] }, properties: { lastAction: 'shortcut' }},
+                            activity: 'service',
+                            arrivalTime: 42900,
+                            departureTime: 45000,
+                            nextPlaceCategory: 'visitedAnotherPlace'
+                        } as any,
+                        p2: {
+                            geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.3, 45.0] }, properties: { lastAction: 'shortcut' }},
+                            activity: 'service',
+                            arrivalTime: 46800,
+                            departureTime: 54000,
+                            nextPlaceCategory: 'visitedAnotherPlace'
+                        } as any
+                    },
+                    trips: {
+                        t1: {
+                            _originVisitedPlaceUuid: 'p1',
+                            _destinationVisitedPlaceUuid: 'p2',
+                            segments: {
+                                s1: {
+                                    _sequence: 1,
+                                    mode: 'transitBus'
+                                }
+                            }
+                        }
+                    }
+                } as any
+            }
+        } as any,
+        previousDay: '2022-09-12',
+        previousBusinessDay: '2022-09-12',
+        _activePersonId: 'a12345'
+    },
+    id: 1,
+    uuid: 'arbitrary',
+    participant_id: 1,
+    is_completed: false,
+    validations: {},
+    is_valid: true
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('access code update', function () {
+    const updateCallback = (updateCallbacks.find((callback) => callback.field === 'accessCode') as any).callback;
+    
+    test('properly formatted access code, with data', async () => {
+        const interview = _cloneDeep(baseInterview);
+
+        // Prepare data to return
+        const prefillData = {
+            'home.address': '123 Main St',
+            'home.city': 'Montreal',
+            'home.postalCode': 'H1A 1A1',
+            'home._addressIsPrefilled': true
+        }
+        preFilledMock.mockResolvedValueOnce(prefillData);
+        const updateResult = await updateCallback(interview, '1111-1111');
+
+        expect(preFilledMock).toHaveBeenCalledWith('1111-1111', interview);
+        expect(updateResult).toEqual({ ...prefillData, accessCodeConfirmed: true });
+        
+    });
+
+    each([
+        ['11111111', '1111-1111'],
+        ['1111 1111', '1111-1111'],
+        ['1111  1111', '1111-1111'],
+    ]).test('access code to reformat, without data %s', async (accessCode, expected) => {
+        const interview = _cloneDeep(baseInterview);
+
+        const updateResult = await updateCallback(interview, accessCode);
+        expect(preFilledMock).toHaveBeenCalledWith(expected, interview);
+        expect(updateResult).toEqual({ accessCode: expected, accessCodeConfirmed: true });
+    });
+
+    test('undefined access code', async() => {
+        const interview = _cloneDeep(baseInterview);
+
+        expect(await updateCallback(interview, undefined)).toEqual({ });
+        expect(preFilledMock).not.toHaveBeenCalled();
+    });
+
+    test('invalid access code', async() => {
+        const interview = _cloneDeep(baseInterview);
+
+        expect(await updateCallback(interview, 'invalid')).toEqual({ });
+        expect(preFilledMock).not.toHaveBeenCalled();
+    });
+
+    test('already confirmed access code', async() => {
+        const interview = _cloneDeep(baseInterview);
+        interview.response.accessCodeConfirmed = true;
+
+        expect(await updateCallback(interview, '1111-1111')).toEqual({ });
+        expect(preFilledMock).not.toHaveBeenCalled();
+    });
+
+    test('error in get prefilled', async () => {
+        const interview = _cloneDeep(baseInterview);
+
+        preFilledMock.mockRejectedValueOnce(new Error('Error getting prefilled data'));
+        const updateResult = await updateCallback(interview, '11111111');
+        expect(preFilledMock).toHaveBeenCalledWith('1111-1111', interview);
+        expect(updateResult).toEqual({ });
+    });
+
+});

--- a/survey/src/survey/server/__tests__/serverValidations.test.ts
+++ b/survey/src/survey/server/__tests__/serverValidations.test.ts
@@ -1,0 +1,22 @@
+import validations from '../serverValidations';
+import each from 'jest-each';
+
+describe('Validate access code', function () {
+    const accessCodeValidation = validations.accessCode.validations;
+
+    each([
+        ['undefined', undefined, false],
+        ['blank', '', true],
+        ['invalid all strings', 'all strings', true],
+        ['valid format', '1234-1234', false],
+        ['valid format with space', '1234 1234', false],
+        ['valid format with many spaces', '1234  1234', false],
+        ['valid format, but with prefix', 'ab1234-1234', true],
+        ['valid format, but with suffix', '1234-1234suf', true],
+        ['no dash', '12341234', false],
+        ['2 dashes', '1234--1234', true]
+    ]).test('Access code: %s, %s, %s', (_title, accessCode, expected) => {
+        expect(accessCodeValidation[0].validation(accessCode)).toEqual(expected);
+    });
+
+});

--- a/survey/src/survey/server/serverFieldUpdate.ts
+++ b/survey/src/survey/server/serverFieldUpdate.ts
@@ -1,0 +1,47 @@
+import { _isBlank, _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { validateAccessCode } from 'evolution-backend/lib/services/accessCode';
+import { getResponse } from 'evolution-common/lib/utils/helpers';
+import { getPreFilledResponseByPath } from 'evolution-backend/lib/services/interviews/serverFieldUpdate';
+import { formatAccessCode } from '../common/helper';
+
+const HOME_ADDRESS_KEY = 'home.address';
+const HOME_ADDRESS_IS_PREFILLED_KEY = 'home._addressIsPrefilled';
+const getPrefilledForAccessCode = async (accessCode, interview) => {
+    const prefilledResponses = await getPreFilledResponseByPath(accessCode, interview);
+    if (prefilledResponses[HOME_ADDRESS_KEY] !== undefined) {
+        prefilledResponses[HOME_ADDRESS_IS_PREFILLED_KEY] = true;
+    }
+    return prefilledResponses;
+};
+
+export default [
+    {
+        field: 'accessCode',
+        callback: async (interview, value) => {
+            try {
+                const properlyFormattedAccessCode = typeof value === 'string' ? formatAccessCode(value) : value;
+                // Only valid access codes should be processed
+                if (_isBlank(value) || !validateAccessCode(properlyFormattedAccessCode)) {
+                    return {};
+                }
+                // To avoid multiple changes to the access code, we check if it has already been confirmed, if so, simply return.
+                const accessCodeConfirmed = getResponse(interview, 'accessCodeConfirmed', false);
+                if (accessCodeConfirmed) {
+                    return {};
+                }
+
+                // Get prefilled responses for this access code
+                const prefilledResponses = await getPrefilledForAccessCode(properlyFormattedAccessCode, interview);
+                if (properlyFormattedAccessCode !== value) {
+                    prefilledResponses['accessCode'] = properlyFormattedAccessCode;
+                }
+                // Set the access code as confirmed
+                prefilledResponses['accessCodeConfirmed'] = true;
+                return prefilledResponses;
+            } catch (error) {
+                console.error('error getting server update fields for accessCode', error);
+                return {};
+            }
+        }
+    }
+];

--- a/survey/src/survey/server/serverValidations.ts
+++ b/survey/src/survey/server/serverValidations.ts
@@ -1,0 +1,19 @@
+import { validateAccessCode, registerAccessCodeValidationFunction } from 'evolution-backend/lib/services/accessCode';
+
+// Access code is 4 digits, dash, 4 digits
+registerAccessCodeValidationFunction((accessCode) => accessCode.match(/^\d{4}-? *\d{4}$/gi) !== null);
+
+export default {
+    accessCode: {
+        validations: [
+            {
+                validation: (value) => typeof value === 'string' && !validateAccessCode(value),
+                // FIXME Server side translations are not as fully integrated as client side with i18next, so we keep hard-coded error messages for now. See https://github.com/chairemobilite/evolution/issues/1061
+                errorMessage: {
+                    fr: 'Code d\'accès invalide.',
+                    en: 'Invalid access code.'
+                }
+            }
+        ]
+    }
+};


### PR DESCRIPTION
fixes #30

When the access code is first entered, get the prefilled data from the prefilled response table.

Also add the server side validation of the access code