### PR TITLE
customPreload: update `responses.` to `response.` in paths

### DIFF
--- a/survey/src/survey/common/customPreloadBase.ts
+++ b/survey/src/survey/common/customPreloadBase.ts
@@ -16,7 +16,7 @@ export default function (interview, sectionShortname) {
         const homeInTerritory = surveyHelperNew.getResponse(interview, 'home._homeIsInTerritory', undefined);
         if (homeInTerritory === false) {
             return {
-                'responses._activeSection': 'completed'
+                'response._activeSection': 'completed'
             };
         }
     }
@@ -26,17 +26,17 @@ export default function (interview, sectionShortname) {
         const countAdults = odSurveyHelper.countAdults({ interview });
         if (countAdults === 0) {
             return {
-                'responses._activeSection': 'completed'
+                'response._activeSection': 'completed'
             };
         }
     }
 
     // Prepare the responses object with the current language, section start time, actions, and household persons count
     const responses = {
-        ['responses._language']: i18n.language, // TODO: follow language changes during the interview
-        [`responses._sections.${sectionShortname}._startedAt`]: moment().unix(),
-        // ['responses._sections._actions']: odSurveyHelper.generateSectionAction(interview, sectionShortname, 'start'),
-        ['responses.household._personsCount']: odSurveyHelper.countPersons({ interview })
+        ['response._language']: i18n.language, // TODO: follow language changes during the interview
+        [`response._sections.${sectionShortname}._startedAt`]: moment().unix(),
+        // ['response._sections._actions']: odSurveyHelper.generateSectionAction(interview, sectionShortname, 'start'),
+        ['response.household._personsCount']: odSurveyHelper.countPersons({ interview })
     };
 
     // Check if household size and persons are in sync
@@ -46,7 +46,7 @@ export default function (interview, sectionShortname) {
         if (!_isBlank(householdSize) && !_isBlank(householdPersons)) {
             const personsCount = odSurveyHelper.countPersons({ interview });
             if (personsCount !== householdSize) {
-                responses['responses.household.size'] = personsCount;
+                responses['response.household.size'] = personsCount;
             }
         }
     }

--- a/survey/src/survey/sections/household/customPreload.ts
+++ b/survey/src/survey/sections/household/customPreload.ts
@@ -28,7 +28,7 @@ export const customPreload: SectionConfig['preload'] = function (
     });
 
     if (householdSizeIsValid && householdSize) {
-        responsesContent['responses.household._personsCount'] = groupedObjectIds.length;
+        responsesContent['response.household._personsCount'] = groupedObjectIds.length;
         if (groupedObjectIds.length < householdSize) {
             // auto create objects according to household size:
             startAddGroupedObjects(
@@ -37,7 +37,7 @@ export const customPreload: SectionConfig['preload'] = function (
                 'household.persons',
                 null,
                 (_interview) => {
-                    responsesContent['responses.household._personsCount'] = householdSize;
+                    responsesContent['response.household._personsCount'] = householdSize;
                     startUpdateInterview(
                         { sectionShortname: currentSectionName, valuesByPath: responsesContent },
                         callback
@@ -54,7 +54,7 @@ export const customPreload: SectionConfig['preload'] = function (
             }
             if (pathsToDelete.length > 0) {
                 startRemoveGroupedObjects(pathsToDelete, (_interview) => {
-                    responsesContent['responses.household._personsCount'] =
+                    responsesContent['response.household._personsCount'] =
                         groupedObjectIds.length - pathsToDelete.length;
                     startUpdateInterview(
                         { sectionShortname: currentSectionName, valuesByPath: responsesContent },
@@ -62,19 +62,19 @@ export const customPreload: SectionConfig['preload'] = function (
                     );
                 });
             } else {
-                responsesContent['responses.household._personsCount'] = groupedObjectIds.length;
+                responsesContent['response.household._personsCount'] = groupedObjectIds.length;
                 startUpdateInterview(
                     { sectionShortname: currentSectionName, valuesByPath: responsesContent },
                     callback
                 );
             }
         } else {
-            responsesContent['responses.household._personsCount'] = groupedObjectIds.length;
+            responsesContent['response.household._personsCount'] = groupedObjectIds.length;
             startUpdateInterview({ sectionShortname: currentSectionName, valuesByPath: responsesContent }, callback);
         }
     } else {
-        responsesContent['responses._activeSection'] = 'home';
-        responsesContent['responses.household._personsCount'] = undefined;
+        responsesContent['response._activeSection'] = 'home';
+        responsesContent['response.household._personsCount'] = undefined;
         startUpdateInterview({ sectionShortname: currentSectionName, valuesByPath: responsesContent }, callback);
     }
     /** End of group related code to move to evolution */


### PR DESCRIPTION
fixes #39

The `responses` field has been renamed in Evolution, customPreload should use this one.