### PR TITLE
survey: set the algorithm to get the assigned day

### DIFF
--- a/survey/config.js
+++ b/survey/config.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 const survey = process.env.EV_VARIANT;
 const variantSpecificConfig = require('./configVariantSpecific')[survey];
 
-const holidays = ['2024-09-02', '2024-10-14', '2024-12-25', '2025-01-01'];
+const holidays = ['2025-09-01', '2025-10-13', '2025-12-25', '2026-01-01'];
 
 moment.updateLocale('fr', {
     holidays,

--- a/survey/package.json
+++ b/survey/package.json
@@ -46,6 +46,7 @@
     "evolution-interviewer": "^0.5.0",
     "i18next": "^24.0.5",
     "moment": "^2.30.1",
+    "moment-business-days": "^1.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^12.3.1",

--- a/survey/src/survey/sections/home/sectionConfigs.ts
+++ b/survey/src/survey/sections/home/sectionConfigs.ts
@@ -6,6 +6,8 @@ import { isSectionCompleted } from 'evolution-common/lib/services/questionnaire/
 import { SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { widgetsNames } from './widgetsNames';
 import { customPreload } from './customPreload';
+import { getResponse } from 'evolution-common/lib/utils/helpers';
+import moment from 'moment';
 
 export const currentSectionName: string = 'home';
 const previousSectionName: SectionConfig['previousSection'] = null;
@@ -34,6 +36,13 @@ export const sectionConfig: SectionConfig = {
     // Allow to click on the section menu
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
+    },
+    onSectionEntry: function (interview, _iterationContext) {
+        const previousDay = getResponse(interview, '_previousDay');
+        if (!previousDay) {
+            return { 'response._previousDay': moment().subtract(1, 'days').format('YYYY-MM-DD') };
+        }
+        return undefined;
     }
 };
 

--- a/survey/src/survey/sections/tripsIntro/customWidgets.ts
+++ b/survey/src/survey/sections/tripsIntro/customWidgets.ts
@@ -113,7 +113,7 @@ export const personDidTrips: WidgetConfig.InputRadioType = {
     label: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
         const nickname = activePerson?.nickname || t('survey:noNickname');
-        const assignedDay = getResponse(interview, 'assignedDay');
+        const assignedDay = getResponse(interview, '_assignedDay');
         const assignedDate = moment(assignedDay).locale(i18n.language).format('dddd LL');
         return t('tripsIntro:personDidTrips', {
             context: activePerson.gender,
@@ -125,7 +125,7 @@ export const personDidTrips: WidgetConfig.InputRadioType = {
     helpPopup: {
         containsHtml: true,
         title: (t: TFunction, interview) => {
-            const assignedDay = getResponse(interview, 'assignedDay');
+            const assignedDay = getResponse(interview, '_assignedDay');
             return t('customLabel:WhyThisDate');
         },
         content: (t: TFunction, interview) => t('customLabel:WhyThisDateExplanation')
@@ -169,7 +169,7 @@ export const personDidTripsChangeConfirm: WidgetConfig.InputRadioType = {
     twoColumns: false,
     label: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
-        const tripsDate = getResponse(interview, 'assignedDay', null);
+        const tripsDate = getResponse(interview, '_assignedDay', null);
         const formattedTripsDate = getFormattedDate(tripsDate as string, { withRelative: true, locale: i18n.language });
         return t('tripsIntro:personDidTripsChangeConfirm', {
             count: odSurveyHelper.getCountOrSelfDeclared({ interview, person: activePerson }),
@@ -183,7 +183,7 @@ export const personDidTripsChangeConfirm: WidgetConfig.InputRadioType = {
             value: 'no',
             label: (t: TFunction, interview) => {
                 const activePerson = odSurveyHelper.getActivePerson({ interview });
-                const tripsDate = getResponse(interview, 'assignedDay', null);
+                const tripsDate = getResponse(interview, '_assignedDay', null);
                 const formattedTripsDate = getFormattedDate(tripsDate as string, {
                     withRelative: true,
                     locale: i18n.language
@@ -199,7 +199,7 @@ export const personDidTripsChangeConfirm: WidgetConfig.InputRadioType = {
             value: 'yes',
             label: (t: TFunction, interview) => {
                 const activePerson = odSurveyHelper.getActivePerson({ interview });
-                const tripsDate = getResponse(interview, 'assignedDay', null);
+                const tripsDate = getResponse(interview, '_assignedDay', null);
                 const formattedTripsDate = getFormattedDate(tripsDate as string, {
                     withRelative: true,
                     locale: i18n.language
@@ -237,7 +237,7 @@ export const visitedPlacesIntro: WidgetConfig.TextWidgetConfig = {
     text: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
         const nickname = activePerson?.nickname || t('survey:noNickname');
-        const tripsDate = getResponse(interview, 'assignedDay', null);
+        const tripsDate = getResponse(interview, '_assignedDay', null);
         const formattedTripsDate = getFormattedDate(tripsDate as string, { withRelative: true, locale: i18n.language });
         return t('tripsIntro:didTripsIntro', {
             context: activePerson.gender,
@@ -277,7 +277,7 @@ export const personDeparturePlaceIsHome: WidgetConfig.InputRadioType = {
     label: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
         const nickname = activePerson?.nickname || t('survey:noNickname');
-        const assignedDay = moment(getResponse(interview, 'assignedDay'));
+        const assignedDay = moment(getResponse(interview, '_assignedDay'));
         const dayBefore = moment(assignedDay).subtract(1, 'days');
         const homeAddress = getHomeAddressOneLine(interview);
         const dayBeforeStr = dayBefore

--- a/survey/src/survey/sections/tripsIntro/sectionConfigs.ts
+++ b/survey/src/survey/sections/tripsIntro/sectionConfigs.ts
@@ -31,7 +31,7 @@ export const sectionConfig: SectionConfig = {
                 1,
                 1,
                 `household.persons.${person._uuid}.journeys`,
-                [{ startDate: getResponse(interview, 'assignedDay') }]
+                [{ startDate: getResponse(interview, '_assignedDay') }]
             );
             const newJourneyKey = Object.keys(newJourneysValuesByPath).find((key) =>
                 key.startsWith(`response.household.persons.${person._uuid}.journeys.`)

--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -54,7 +54,7 @@ export const personVisitedPlacesTitle = {
     containsHtml: true,
     text: (t: TFunction, interview) => {
         const person = odSurveyHelpers.getActivePerson({ interview });
-        const assignedDay = getResponse(interview, 'assignedDay') as string;
+        const assignedDay = getResponse(interview, '_assignedDay') as string;
         const assignedDate = getFormattedDate(assignedDay, { withDayOfWeek: true, withRelative: true });
 
         return t('visitedPlaces:personVisitedPlacesTitle', {

--- a/survey/src/survey/server/serverFieldUpdate.ts
+++ b/survey/src/survey/server/serverFieldUpdate.ts
@@ -1,9 +1,13 @@
+import moment from 'moment-business-days';
 import { _isBlank, _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { validateAccessCode } from 'evolution-backend/lib/services/accessCode';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { getPreFilledResponseByPath } from 'evolution-backend/lib/services/interviews/serverFieldUpdate';
+import { randomFromDistribution } from 'chaire-lib-common/lib/utils/RandomUtils';
+import interviewsDbQueries from 'evolution-backend/lib/models/interviews.db.queries';
 import { formatAccessCode } from '../common/helper';
 
+// *** Code for the home address prefill **
 const HOME_ADDRESS_KEY = 'home.address';
 const HOME_ADDRESS_IS_PREFILLED_KEY = 'home._addressIsPrefilled';
 const getPrefilledForAccessCode = async (accessCode, interview) => {
@@ -14,7 +18,137 @@ const getPrefilledForAccessCode = async (accessCode, interview) => {
     return prefilledResponses;
 };
 
+// *** Code for the assigned day ***
+const assignedDayPath = '_assignedDay';
+const originalAssignedDayPath = '_originalAssignedDay';
+const ASSIGNED_DAY_UPDATE_FREQ_MINUTES = 15;
+let lastCheckMoment = undefined;
+const assignedDays = [0, 0, 0, 0, 0, 0, 0];
+const assignedDayTarget = [0.2, 0.2, 0.2, 0.2, 0.2, 0, 0];
+const defaultProbabilityOfDaysBefore = [0.6, 0.2, 0.13, 0.07];
+const getAssignedDayRates = (): number[] | undefined => {
+    const total = assignedDays.reduce((sum, current) => sum + current, 0);
+    // Do not play with days below 500 surveys
+    if (total < 500) {
+        return undefined;
+    }
+    return assignedDays.map((dayCount) => dayCount / total);
+};
+
+// Exported so it can be called in unit tests
+export const updateAssignedDayRates = async () => {
+    console.log('Updating assigned day rates...');
+    // Filter completed interviews only and interviews that are not invalid (value can be null or true, so we need to use 'not' false)
+    const filters = {
+        'response._isCompleted': { value: true },
+        is_valid: { value: false, op: 'not' as const }
+    };
+    if (lastCheckMoment !== undefined) {
+        filters['response._completedAt'] = { value: Math.ceil(lastCheckMoment.valueOf() / 1000), op: 'gte' };
+    }
+    const currentCheck = moment();
+    lastCheckMoment = currentCheck;
+    let interviewCount = 0;
+    const queryStream = interviewsDbQueries.getInterviewsStream({
+        filters,
+        select: { responseType: 'correctedIfAvailable', includeAudits: false }
+    });
+    return new Promise<void>((resolve, reject) => {
+        queryStream
+            .on('error', (error) => {
+                console.error('queryStream failed', error);
+                reject(error);
+            })
+            .on('data', (row) => {
+                const interview = row;
+                interviewCount++;
+
+                const assignedDate = getResponse(interview, assignedDayPath);
+                if (assignedDate !== undefined) {
+                    const momentDay = moment(assignedDate);
+                    if (momentDay.isHoliday() && momentDay.isoWeekday() < 6) {
+                        // Holiday in a weekday, ignore from count
+                        return;
+                    }
+                    assignedDays[momentDay.isoWeekday() - 1]++;
+                }
+            })
+            .on('end', () => {
+                console.log('Updated assigned day rates with the data from %d interviews', interviewCount);
+                resolve();
+            });
+    });
+};
+
+const periodicAssignedDatRatesUpdate = async () => {
+    await updateAssignedDayRates();
+    setTimeout(periodicAssignedDatRatesUpdate, ASSIGNED_DAY_UPDATE_FREQ_MINUTES * 60 * 1000); // Update every X minutes
+};
+
+// To avoid the first query when the server restarts to be long when there's a lot of data, make it run asynchronously now.
+try {
+    console.log('Calculating assigned day rates for the first time');
+    periodicAssignedDatRatesUpdate().then(() => {
+        console.log('Assigned day rates at start:', assignedDays.toString());
+    });
+} catch (error) {
+    console.error('Error at first calculation of assigned day rates: ', error);
+}
+
 export default [
+    {
+        field: '_previousDay',
+        callback: async (interview, value) => {
+            const assignedDay = getResponse(interview, assignedDayPath);
+            if (!_isBlank(assignedDay)) {
+                // already assigned
+                return {};
+            }
+            try {
+                const prevDay = moment(value);
+                const dow = prevDay.isoWeekday() - 1;
+                const currentDayRates = getAssignedDayRates();
+                if (currentDayRates === undefined && assignedDayTarget[dow] !== 0) {
+                    return { [assignedDayPath]: value, [originalAssignedDayPath]: value };
+                }
+                const probabilities = [];
+                // Divide target by current rate and put to the power of 3, then multiply by default probability.
+                // FIXME Fine-tune if necessary
+                for (let i = 0; i < 4; i++) {
+                    const dow = !prevDay.isHoliday() ? prevDay.isoWeekday() - 1 : 6;
+                    probabilities.push(
+                        assignedDayTarget[dow] === 0
+                            ? 0
+                            : Math.max(
+                                0.01,
+                                Math.pow(
+                                    assignedDayTarget[dow] /
+                                          Math.max(0.005, currentDayRates === undefined ? 1 : currentDayRates[dow]),
+                                    3
+                                )
+                            ) *
+                                  defaultProbabilityOfDaysBefore[i] *
+                                  100
+                    );
+                    prevDay.subtract(1, 'days');
+                }
+
+                const totalProbability = probabilities.reduce((total, prob) => total + prob, 0);
+                const daysBeforePrevDay = randomFromDistribution(probabilities, undefined, totalProbability);
+                const formattedAssignedDay = (
+                    daysBeforePrevDay > 0 ? moment(value).subtract(daysBeforePrevDay, 'days') : moment(value)
+                ).format('YYYY-MM-DD');
+                return {
+                    [assignedDayPath]: formattedAssignedDay,
+                    [originalAssignedDayPath]: formattedAssignedDay
+                };
+            } catch (error) {
+                console.error('Error getting the assigned day for survey', error);
+                // Error, fallback to previous business day
+                return { [assignedDayPath]: value, [originalAssignedDayPath]: value };
+            }
+        }
+    },
     {
         field: 'accessCode',
         callback: async (interview, value) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10100,6 +10100,11 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==
 
+moment-business-days@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-business-days/-/moment-business-days-1.2.0.tgz#6172f9f38dbf443c2f859baabeabbd2935f63d65"
+  integrity sha512-QJlceLfMSxy/jZSOgJYCKeKw+qGYHj8W0jMa/fYruyoJ85+bJuLRiYv5DIaflyuRipmYRfD4kDlSwVYteLN+Jw==
+
 moment-timezone@^0.5.33:
   version "0.5.48"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"


### PR DESCRIPTION
fixes #31

Add a dependency to `moment-business-days` as it has utility functions to get the holidays, and as long as we use `moment`, we might as well also use the utility modules that accompany it.

Configure the holidays for the fall 2025 in Quebec.

Set the `previousDay` in the `home` section's `onSectionEntry` function.

Copy the code for the `serverFieldUpdate` to set the `assignedDay` when the `previousDay` is set from the `od_nationale_2024`. This is a probabilistic algorithm that checks the probability of being asked the trips for 1 to 4 days prior to the survey date, depending on the number of completed interview for each days of the week. To avoid too many memory bias for the same days, there is always a higher probability multiplicator for the days closest to the previous day.