### PR TITLE
ci: set the NODE_ENV to production for import step

### DIFF
--- a/.github/workflows/survey-ui-test.yml
+++ b/.github/workflows/survey-ui-test.yml
@@ -56,6 +56,8 @@ jobs:
         NODE_ENV: production
     - name: Prepare prefilled data for the tests
       run: yarn node evolution/packages/evolution-backend/lib/tasks/importPreFilledResponses.task.js --file "$(pwd)/survey/tests/preFilledDataSample.csv"
+      env:
+        NODE_ENV: production
     - name: Get Playwright config
       run: cp packages/evolution-frontend/playwright-example.config.ts survey/playwright.config.ts
     - name: Start application


### PR DESCRIPTION
it was trying to import in the wrong database, the development one, that does not exist