### PR TITLE
webpack: Set the initial title to the survey's title

### DIFF
--- a/survey/webpack.admin.config.js
+++ b/survey/webpack.admin.config.js
@@ -43,6 +43,10 @@ module.exports = (env) => {
     path.join(__dirname, 'assets')
   ];
 
+  // Get the default title from the config or use a fallback
+  const defaultLanguage = config.languages && config.languages.length > 0 ? config.languages[0] : 'fr';
+  const defaultAppTitle = config.title && config.title[defaultLanguage] ? config.title[defaultLanguage] : process.env.DEFAULT_TITLE || 'Evolution';
+
   return {
     // Controls which information to display (see https://webpack.js.org/configuration/stats/)
     stats: {
@@ -129,6 +133,8 @@ module.exports = (env) => {
         cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!documents/**', '!*.html'],
       }),
       new HtmlWebpackPlugin({
+        title: defaultAppTitle,
+        noindex: true,
         filename: path.join(`index-survey-${config.projectShortname}.html`),
         template: path.join(publicDirectory, 'index.html'),
       }),

--- a/survey/webpack.config.js
+++ b/survey/webpack.config.js
@@ -42,6 +42,10 @@ module.exports = (env) => {
         path.join(__dirname, 'assets')
     ];
 
+    // Get the default title from the config or use a fallback
+    const defaultLanguage = config.languages && config.languages.length > 0 ? config.languages[0] : 'fr';
+    const defaultAppTitle = config.title && config.title[defaultLanguage] ? config.title[defaultLanguage] : process.env.DEFAULT_TITLE || 'Evolution';
+
     return {
         // Controls which information to display (see https://webpack.js.org/configuration/stats/)
         stats: {
@@ -130,6 +134,7 @@ module.exports = (env) => {
                 cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!documents/**', '!*.html']
             }),
             new HtmlWebpackPlugin({
+                title: defaultAppTitle,
                 filename: path.join(`index-survey-${config.projectShortname}.html`),
                 template: path.join(publicDirectory, 'index.html')
             }),


### PR DESCRIPTION
fixes #75

Use in the first language in the configuration's `languages` field as the default language and the corresponding `title` for the language as the default. If it is not set, fallback to the environment variable `DEFAULT_TITLE` (the one used in the demo_survey webpack) and fallback again to "Evolution", to avoid having "Webpack app" as the title.

Also set the admin's `noindex` value to `true` to avoid admin apps being indexed by robots.