### PR TITLE
config: ajout de la variante Saguenay

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
-        ev-variant: [nationale, sherbrooke, troisrivieresbecancour]
+        ev-variant: [nationale, saguenay]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/survey/config.js
       EV_VARIANT: ${{ matrix.ev-variant }}

--- a/survey/configVariantSpecific.js
+++ b/survey/configVariantSpecific.js
@@ -1,46 +1,25 @@
 module.exports = {
-    sherbrooke: {
-        trRoutingScenarios: {
-            SE: '4349d0c8-f36e-4924-b087-4f09ff61e6d1',
-            SA: 'fa264668-f9e1-4ef6-8b0a-f79fc128ee7d',
-            DI: '8b1ef717-c5f1-4968-ba8d-e00be4cd5104'
-        },
+    saguenay: {
+        // FIXME Need to setup Transition scenarios for Saguenay
+        /*trRoutingScenarios: {
+            SE: 'scenario uuid for week days',
+            SA: 'scenario uuid for saturday',
+            DI: 'scenario uuid for sunday'
+        }, */
         mapDefaultCenter: {
-            lat: 45.40229,
-            lon: -71.88846
+            lat: 48.397538,
+            lon: -71.20195
         },
         mapMaxGeocodingResultsBounds: [{
-            lat: 45.5405672,
-            lng: -71.717510
+            lat: 48.685988478,
+            lng: -70.6606085455
         }, {
-            lat: 45.218488,
-            lng: -72.195862
+            lat: 48.220212043992,
+            lng: -71.61559638814
         }],
         title: {
-            fr: "Enquête Origine-Destination 2024",
-            en: "2024 Origin-Destination Survey "
-        }
-    },
-    troisrivieresbecancour:{
-        trRoutingScenarios: {
-            SE: 'c1b7451a-e16b-47e5-b10c-e91371dd3217',
-            SA: '793ae097-518e-46ec-b763-e8cca3446b02',
-            DI: '50147472-a7e4-46cc-ad39-0e19198dfe19'
-        },
-        mapDefaultCenter: {
-            lat: 46.34309,
-            lon: -72.54201
-        },
-        mapMaxGeocodingResultsBounds: [{
-            lat: 46.482701,
-            lng: -72.39686
-        }, {
-            lat: 46.1856657,
-            lng: -72.64123
-        }],
-        title: {
-            fr: "Enquête Origine-Destination 2024",
-            en: "2024 Origin-Destination Survey "
+            fr: "Enquête Origine-Destination 2025",
+            en: "2025 Origin-Destination Survey "
         }
     },
     nationale: {


### PR DESCRIPTION
Et ajout de `saguenay` dans la matrice de CI

Règle en partie #42 avec des valeurs arbitraires, à confirmer, mais au moins la variante Saguenay fonctionnera autour de la ville de Saguenay.