### PR TITLE
UI Testing: Trying to fix the problems with two-persons-no-trips UI tests

### DIFF
--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -523,7 +523,6 @@ export const fillTripsintroSectionTests = ({ context, householdSize = 1 }: Commo
         }
 
         // Test custom widget personDidTrips
-        // TODO: This only works with 'yes' value. Don't know why... With 'no' value, it doesn't check the input...
         testHelpers.inputRadioTest({
             context,
             path: 'household.persons.${activePersonId}.journeys.${activeJourneyId}.personDidTrips',

--- a/survey/tests/test-two-persons-no-trips.UI.spec.ts
+++ b/survey/tests/test-two-persons-no-trips.UI.spec.ts
@@ -43,11 +43,11 @@ commonUITestsHelpers.fillHouseholdSectionTests({ context, householdSize: 2 });
 // TODO: Understand why this section is skipped for household size 2
 // commonUITestsHelpers.fillSelectPersonSectionTests({ context, householdSize: 2 });
 
-// /********** Tests tripsIntro section **********/
-// commonUITestsHelpers.fillTripsintroSectionTests({ context, householdSize: 2 });
+/********** Tests tripsIntro section **********/
+commonUITestsHelpers.fillTripsintroSectionTests({ context, householdSize: 2 });
 
-// /********** Tests end section **********/
-// commonUITestsHelpers.fillEndSectionTests({ context, householdSize: 2 });
+/********** Tests end section **********/
+commonUITestsHelpers.fillEndSectionTests({ context, householdSize: 2 });
 
-// /********** Tests completed section **********/
-// commonUITestsHelpers.fillCompletedSectionTests({ context, householdSize: 2 });
+/********** Tests completed section **********/
+commonUITestsHelpers.fillCompletedSectionTests({ context, householdSize: 2 });


### PR DESCRIPTION
# Pull request
Fix: #13

- [x] We need to understand and fix the problem before pushing.
- [x] We are trying to fix https://github.com/chairemobilite/od_nationale_quebec/issues/13
- [x] Rebase from main

## Description
UI Testing: Add every section for two-persons with no trips tests. 
After the last Evolution updated, the application is now working properly and we can tests all section.

## Screenshot
These are some screenshots of Playwright.
<img width="1031" height="629" alt="image" src="https://github.com/user-attachments/assets/72b237a2-d13a-452f-93c3-cd1b2d4c8e7c" />
 
<img width="790" height="473" alt="image" src="https://github.com/user-attachments/assets/875e1a0f-58ad-4124-be32-c59aafb6204a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Reactivated previously skipped UI test steps in the two-person, no-trips journey: trips intro, end, and completion sections, ensuring these flows are validated.
  * Updated section headers to block comments; no runtime effect.
  * Removed an obsolete TODO in shared UI test helpers; test logic unchanged.
  * No changes to application behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->