### PR TITLE
tests: delete participant in `afterAll` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Pour importer les données à pré-remplir, exécuter la commande suivante, avec
 yarn node evolution/packages/evolution-backend/lib/tasks/importPreFilledResponses.task.js --file "$(pwd)/survey/tests/preFilledDataSample.csv"
 ```
 
-Pour nettoyer les données locales avant de rouler les tests UI, sans toucher aux autres entrevues manuelles, exécuter la tâche `yarn reset:test:ui`. Cette commande supprimera tous les participants dont le code d'accès débute par `7357-`. Assurez-vous d’être connecté à une base de données de développement; ne jamais exécuter cette commande sur une base de production.
+Suite à chaque test, un hook `afterAll` supprimera le participant (et toutes les données associées). Pour conserver le données de test pour fins de débogage, il est possible de commenter ce hook dans chaque test. Pour nettoyer les données locales manuellement avant de rouler les tests UI, sans toucher aux autres entrevues manuelles, exécuter la tâche `yarn reset:test:ui`. Cette commande supprimera tous les participants dont le code d'accès débute par `7357-`. Assurez-vous d’être connecté à une base de données de développement; ne jamais exécuter cette commande sur une base de production.
 
 Avant d'exécuter les tests UI, assurez-vous également d'utiliser le bon fichier de configuration Playwright. Par défaut, copiez le fichier d'exemple fourni :
 

--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -1,4 +1,5 @@
 import { test } from '@playwright/test';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
 import { SurveyObjectDetector } from 'evolution-frontend/tests/ui-testing/SurveyObjectDetectors';
 
@@ -8,6 +9,16 @@ const context = {
     title: '',
     widgetTestCounters: {}
 };
+
+// Function to run in the `afterAll` hook to delete the participant interview, to allow retries to reset the state to its original value
+export const deleteParticipantInterview = async (accessCode: string) => {
+    try {
+        // Delete the participant interview with the access code
+        await knex('sv_participants').del().whereILike('username', `${accessCode}-%`);
+    } catch (error) {
+        console.error(`Error deleting participant with access code ${accessCode}`, error);
+    }
+}
 
 // Modify the CommonTestParameters type with survey parameters
 export type CommonTestParametersModify = testHelpers.CommonTestParameters & {

--- a/survey/tests/test-one-person-no-trips.UI.spec.ts
+++ b/survey/tests/test-one-person-no-trips.UI.spec.ts
@@ -11,6 +11,10 @@ const context = {
     widgetTestCounters: {}
 };
 
+// Survey credentials
+const postalCode = 'G1R 5H1';
+const accessCode = '7357-1111';
+
 // Configure the tests to run in serial mode (one after the other)
 test.describe.configure({ mode: 'serial' });
 
@@ -19,11 +23,13 @@ test.beforeAll(async ({ browser }) => {
     context.page = await testHelpers.initializeTestPage(browser, context.objectDetector);
 });
 
+test.afterAll(async() => {
+    // Delete the participant after the test
+    await commonUITestsHelpers.deleteParticipantInterview(accessCode);
+});
+
 /********** Start the survey **********/
-// Start the survey using an access code and postal code combination that does not exist in the database.
-// The survey should still start a new interview with these credentials.
-const postalCode = 'G1R 5H1';
-const accessCode = '7357-1111';
+// Start the survey using an access code and postal code combination
 surveyTestHelpers.startAndLoginWithAccessAndPostalCodes({
     context,
     title: 'Enquête Nationale Origine-Destination 2025',

--- a/survey/tests/test-two-persons-no-trips.UI.spec.ts
+++ b/survey/tests/test-two-persons-no-trips.UI.spec.ts
@@ -11,6 +11,10 @@ const context = {
     widgetTestCounters: {}
 };
 
+// Survey credentials
+const postalCode = 'G5A 1E7';
+const accessCode = '7357-1114';
+
 // Configure the tests to run in serial mode (one after the other)
 test.describe.configure({ mode: 'serial' });
 
@@ -19,11 +23,13 @@ test.beforeAll(async ({ browser }) => {
     context.page = await testHelpers.initializeTestPage(browser, context.objectDetector);
 });
 
+test.afterAll(async() => {
+    // Delete the participant after the test
+    await commonUITestsHelpers.deleteParticipantInterview(accessCode);
+});
+
 /********** Start the survey **********/
-// Start the survey using an access code and postal code combination that does not exist in the database.
-// The survey should still start a new interview with these credentials.
-const postalCode = 'G5A 1E7';
-const accessCode = '7357-1114';
+// Start the survey using an access code and postal code combination
 surveyTestHelpers.startAndLoginWithAccessAndPostalCodes({
     context,
     title: 'Enquête Nationale Origine-Destination 2025',


### PR DESCRIPTION
fixes #117

Delete the participant with the tests's accessCode at the end of the test. This will ensure a consistent initial state, with an interview that does not exist.