### PR TITLE
questionnaire: fix path of `whoWillAnswerForThisPerson`

### DIFF
--- a/survey/src/survey/sections/tripsIntro/customWidgets.ts
+++ b/survey/src/survey/sections/tripsIntro/customWidgets.ts
@@ -68,7 +68,7 @@ export const personNewPerson = {
 // FIXME Custom because of the choices
 export const personWhoWillAnswerForThisPerson: WidgetConfig.InputRadioType = {
     type: 'question',
-    path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.whoWillAnswerForThisPerson',
+    path: 'household.persons.{_activePersonId}.whoWillAnswerForThisPerson',
     inputType: 'radio',
     datatype: 'string',
     twoColumns: false,

--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -571,7 +571,7 @@ export const fillTripsintroSectionTests = ({ context, householdSize = 1, expectP
         if (householdSize >= 2) {
             testHelpers.inputRadioTest({
                 context,
-                path: 'household.persons.${activePersonId}.journeys.${activeJourneyId}.whoWillAnswerForThisPerson',
+                path: 'household.persons.${activePersonId}.whoWillAnswerForThisPerson',
                 value: '${activePersonId}' // Select the current person
             });
         }


### PR DESCRIPTION
fixes #144

This path is built in Evolution, under the `Person` object and is used to determine if a person is self declared or a proxy, which can impact the labels and the question visibility.