### PR TITLE
selectPerson: show persons in their random order instead of sequential

### DIFF
--- a/survey/src/survey/sections/selectPerson/customWidgets.tsx
+++ b/survey/src/survey/sections/selectPerson/customWidgets.tsx
@@ -19,28 +19,45 @@ export const selectPerson: WidgetConfig.InputRadioType = {
     containsHtml: true,
     label: (t: TFunction) => t('selectPerson:_activePersonId'),
     choices: function (interview) {
-        const interviewablePersons = odSurveyHelper.getInterviewablePersonsArray({ interview });
-        return interviewablePersons.map((person, index) => {
-            let icon = faPortrait;
-            if (person.age < 15) {
-                icon = faChild;
-            } else if (person.gender === 'male') {
-                icon = faMale;
-            } else if (person.gender === 'female') {
-                icon = faFemale;
-            }
-            return {
-                value: person._uuid,
-                label: {
-                    fr: `<div style={{display: 'flex', alignItems: 'center', fontSize: '150%', fontWeight: 300}}><FontAwesomeIcon icon={icon} className="faIconLeft" style={{width: '4rem', height: '4rem'}} />Personne ${
-                        index + 1
-                    } • ${person.nickname} (${person.age} ans)</div>`,
-                    en: `<div style={{display: 'flex', alignItems: 'center', fontSize: '150%', fontWeight: 300}}><FontAwesomeIcon icon={icon} className="faIconLeft" style={{width: '4rem', height: '4rem'}} />Person ${
-                        index + 1
-                    } • ${person.nickname} (${person.age} years old)</div>`
+        const persons = odSurveyHelper.getPersons({ interview });
+        let personsRandomSequence = getResponse(interview, '_personRandomSequence') as string[] | null;
+        if (!Array.isArray(personsRandomSequence) || personsRandomSequence.length === 0) {
+            console.error(
+                'No person random sequence found in interview to fill the select person widget. Will fallback to interviewable persons'
+            );
+            const interviewablePersons = odSurveyHelper.getInterviewablePersonsArray({ interview });
+            personsRandomSequence = interviewablePersons.map((person) => person._uuid);
+        }
+        return personsRandomSequence
+            .map((personId, index) => {
+                const person = persons[personId];
+                if (!person) {
+                    console.error(
+                        `Person with ID ${personId} not found in interview. This should not happen, check the interview data.`
+                    );
+                    return null; // Skip this person if not found
                 }
-            };
-        });
+                let icon = faPortrait;
+                if (person.age < 15) {
+                    icon = faChild;
+                } else if (person.gender === 'male') {
+                    icon = faMale;
+                } else if (person.gender === 'female') {
+                    icon = faFemale;
+                }
+                return {
+                    value: person._uuid,
+                    label: {
+                        fr: `<div style={{display: 'flex', alignItems: 'center', fontSize: '150%', fontWeight: 300}}><FontAwesomeIcon icon={icon} className="faIconLeft" style={{width: '4rem', height: '4rem'}} />Personne ${
+                            index + 1
+                        } • ${person.nickname} (${person.age} ans)</div>`,
+                        en: `<div style={{display: 'flex', alignItems: 'center', fontSize: '150%', fontWeight: 300}}><FontAwesomeIcon icon={icon} className="faIconLeft" style={{width: '4rem', height: '4rem'}} />Person ${
+                            index + 1
+                        } • ${person.nickname} (${person.age} years old)</div>`
+                    }
+                };
+            })
+            .filter((person) => person !== null); // Filter out any null values
     },
     validations: (value) => {
         return [


### PR DESCRIPTION
fixes #143

The list of persons from which to select should match the random order in which they should be interviewed instead of the sequential order. Otherwise, when the last person is selected, instead of going to the End section, it may return to the `selectPerson` section with a previous person selected. That is confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures the “Select Person” list displays in a consistent, predefined order when a stored sequence is present, with a deterministic fallback.
  - Skips missing or invalid persons so broken/empty options are not shown; numbering reflects the new ordering.
- Refactor
  - Builds choices from a centralized person lookup plus explicit ordering sequence.
  - Adds runtime safeguards and logs while preserving localized labels and age/gender icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->