### PR TITLE
tripsIntro: fix the behavior of `personDidTripsChangeConfirm`

### DIFF
--- a/survey/src/survey/sections/tripsIntro/customWidgets.ts
+++ b/survey/src/survey/sections/tripsIntro/customWidgets.ts
@@ -169,7 +169,7 @@ export const personDidTripsChangeConfirm: WidgetConfig.InputRadioType = {
             count: odSurveyHelper.getCountOrSelfDeclared({ interview, person: activePerson }),
             nickname: activePerson.nickname,
             context: activePerson.gender,
-            assignedDate: formattedTripsDate
+            formattedTripsDate
         });
     },
     choices: [
@@ -211,7 +211,7 @@ export const personDidTripsChangeConfirm: WidgetConfig.InputRadioType = {
         if (activeJourney === null) {
             return [false, null];
         }
-        const personDidTrips = getResponse(interview, '../personDidTrips', null);
+        const personDidTrips = getResponse(interview, path, null, '../personDidTrips');
         const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({
             journey: activeJourney
         });

--- a/survey/src/survey/sections/visitedPlaces/sectionConfigs.ts
+++ b/survey/src/survey/sections/visitedPlaces/sectionConfigs.ts
@@ -155,7 +155,11 @@ export const sectionConfig: SectionConfig = {
             personId: iterationContext[iterationContext.length - 1]
         }) as any;
         const journey = person ? odSurveyHelper.getJourneysArray({ person })[0] : undefined;
-        return journey && (journey as any).personDidTrips === 'yes';
+        // Visible if either the person says has trips or has confirmed she still have trips (the value will be reset later on tripsIntro exit)
+        return (
+            journey &&
+            ((journey as any).personDidTrips === 'yes' || (journey as any).personDidTripsChangeConfirm === 'yes')
+        );
     }
 };
 


### PR DESCRIPTION
fixes #38

Fix the path of the `personDidTrips` answer in the `personDidTripsChangeConfirm` conditional, as well as the formattedTripsDate label.

Add a `onSectionExit` function to the `tripsIntro` section to act on the values of the `personDidTripsChangeConfirm` response. Either reset the value of `personDidTrips` if the persons did trips after all, or delete the visited places and trips from the journey.

Make the `visitedPlaces` visible if either personDidTrips or personDidTripsChangeConfirm is `true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automatic updates when leaving the Trips Intro: confirming a change can reset previously entered places and trips or confirm trip participation as needed.
  - Improved section visibility: the Visited Places section now appears when either trips are confirmed or a change is confirmed.
- Bug Fixes
  - Confirmation message now displays the correct formatted date.
  - More reliable answer lookups within widgets, ensuring context-aware behavior across repeated sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->