### PR TITLE
segments: utilisation des icônes de mode d'Evolution

### DIFF
--- a/survey/src/survey/sections/segments/customWidgets.ts
+++ b/survey/src/survey/sections/segments/customWidgets.ts
@@ -533,10 +533,10 @@ const segmentModeChoices: WidgetConfig.RadioChoiceType[] = [
             const person = odSurveyHelpers.getActivePerson({ interview });
             // paratransit can be used by an accompanying person too, so show this mode for any household with at least one person with disability:
             return (
-                (['transit', 'other', 'carPassenger', 'paratransit'].includes(modePre) &&
-                    person &&
-                    odSurveyHelpers.personMayHaveDisability({ person })) ||
-                odSurveyHelpers.householdMayHaveDisability({ interview })
+                ['transit', 'other', 'carPassenger', 'paratransit'].includes(modePre) &&
+                person &&
+                (odSurveyHelpers.personMayHaveDisability({ person }) ||
+                    odSurveyHelpers.householdMayHaveDisability({ interview }))
             );
         },
         iconPath: getModeIcon('paratransit')


### PR DESCRIPTION
Utilisation de la fonction `getModeIcon` d'Evolution pour déterminer l'icône à montrer pour chaque mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized transportation mode icons across survey segments for consistent display.
  * Updated several transit mode icons to new categories (RRT, LRT, Regional Rail, Streetcar, Ferry).
  * Refined paratransit eligibility checks to require an active respondent and more accurate disability gating.
  * Corrected electric bicycle icon handling (special-case retained with note for follow-up).

* **New Features**
  * Added plane as a selectable mode.

* **Refactor**
  * Centralized mode icon sourcing to a shared mapping for easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->