### PR TITLE
webpack: add the `icons` path not to be clean in prod mode

### DIFF
--- a/survey/webpack.admin.config.js
+++ b/survey/webpack.admin.config.js
@@ -130,7 +130,7 @@ module.exports = (env) => {
       new CleanWebpackPlugin({
         dry: !isProduction,
         verbose: true,
-        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!documents/**', '!*.html'],
+        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!documents/**', '!*.html'],
       }),
       new HtmlWebpackPlugin({
         title: defaultAppTitle,

--- a/survey/webpack.config.js
+++ b/survey/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = (env) => {
             new CleanWebpackPlugin({
                 dry: !isProduction,
                 verbose: true,
-                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!documents/**', '!*.html']
+                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!documents/**', '!*.html']
             }),
             new HtmlWebpackPlugin({
                 title: defaultAppTitle,


### PR DESCRIPTION
fixes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Icons are now reliably preserved after updates, preventing missing or broken icon graphics across the app.
  * Improves consistency of visual elements (e.g., navigation and action icons) across pages and sessions.

* Chores
  * Adjusted build cleanup rules to safeguard icon assets in future releases, reducing the risk of accidental asset removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->