### PR TITLE
visitedPlaces: use `requiredValidation` where possible

### DIFF
--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -1093,14 +1093,7 @@ export const visitedPlacePreviousPreviousDepartureTime: WidgetConfig.InputTimeTy
     containsHtml: true,
     addHourSeparators: true,
     minuteStep: 5,
-    validations: function (value, customValue, interview, path, customPath) {
-        return [
-            {
-                validation: _isBlank(value),
-                errorMessage: (t: TFunction) => t('survey:ResponseIsRequiredError')
-            }
-        ];
-    },
+    validations: validations.requiredValidation,
     conditional: function (interview, path) {
         const journey = odSurveyHelpers.getActiveJourney({ interview });
         const activeVisitedPlace = odSurveyHelpers.getActiveVisitedPlace({ interview, journey });
@@ -1261,14 +1254,7 @@ export const visitedPlacePreviousArrivalTime: WidgetConfig.InputTimeType = {
     containsHtml: true,
     addHourSeparators: true,
     minuteStep: 5,
-    validations: function (value, customValue, interview, path, customPath) {
-        return [
-            {
-                validation: _isBlank(value),
-                errorMessage: (t: TFunction) => t('survey:ResponseIsRequiredError')
-            }
-        ];
-    },
+    validations: validations.requiredValidation,
     conditional: function (interview, path) {
         const journey = odSurveyHelpers.getActiveJourney({ interview });
         const activeVisitedPlace = odSurveyHelpers.getActiveVisitedPlace({ interview, journey });
@@ -1440,14 +1426,7 @@ export const visitedPlacePreviousDepartureTime: WidgetConfig.InputTimeType = {
     twoColumns: false,
     containsHtml: true,
     addHourSeparators: true,
-    validations: function (value, customValue, interview, path, customPath) {
-        return [
-            {
-                validation: _isBlank(value),
-                errorMessage: (t: TFunction) => t('survey:ResponseIsRequiredError')
-            }
-        ];
-    },
+    validations: validations.requiredValidation,
     minuteStep: (interview, path) => {
         const journey = odSurveyHelpers.getActiveJourney({ interview });
         const activeVisitedPlace = odSurveyHelpers.getActiveVisitedPlace({ interview, journey });
@@ -1622,14 +1601,7 @@ export const visitedPlaceArrivalTime: WidgetConfig.InputTimeType = {
     containsHtml: true,
     addHourSeparators: true,
     minuteStep: 5,
-    validations: function (value, customValue, interview, path, customPath) {
-        return [
-            {
-                validation: _isBlank(value),
-                errorMessage: (t: TFunction) => t('survey:ResponseIsRequiredError')
-            }
-        ];
-    },
+    validations: validations.requiredValidation,
     conditional: function (interview, path) {
         const journey = odSurveyHelpers.getActiveJourney({ interview });
         const activeVisitedPlace = odSurveyHelpers.getActiveVisitedPlace({ interview, journey });


### PR DESCRIPTION
fixes #210

Except where the error message needs to be more explicit, we can use the builtin requiredValidation function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - None.

- Refactor
  - Standardized required-field validation across time inputs in the Visited Places section (e.g., previous stop arrival/departure and current arrival times).
  - Ensures consistent required-field behavior and error messages for these fields.
  - No changes to how users complete the survey; behavior remains the same.

- Chores
  - Reduced duplicate validation logic to improve maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->