### PR TITLE
admin: setup the interviewer roles for the survey

### DIFF
--- a/survey/locales/en/customLabel.yaml
+++ b/survey/locales/en/customLabel.yaml
@@ -29,3 +29,4 @@ WhyThisDateExplanation: >-
     summary, with a large number of responses for days randomly assigned, the
     aggregate of all responses should accurately reflect an average day of
     travel for the population surveyed.</p>
+Interviewers: Interviewers

--- a/survey/locales/fr/customLabel.yaml
+++ b/survey/locales/fr/customLabel.yaml
@@ -28,3 +28,4 @@ WhyThisDateExplanation: >-
     résumé, avec un grand nombre de réponses pour des jours attribués de manière
     aléatoire, l'agrégé des données devrait tendre vers une modélisation
     réaliste d'un jour moyen pour l'ensemble de la population recensée.</p>
+Interviewers: Intervieweurs

--- a/survey/src/admin/app-admin.tsx
+++ b/survey/src/admin/app-admin.tsx
@@ -8,15 +8,23 @@ import runClientApp from 'evolution-frontend/lib/apps/admin';
 import { setApplicationConfiguration } from 'chaire-lib-frontend/lib/config/application.config';
 import appConfig, { EvolutionApplicationConfiguration } from 'evolution-frontend/lib/config/application.config';
 import VisitedPlaceSection from '../survey/sections/visitedPlaces/template';
+import addInterviewerOptions from 'evolution-interviewer/lib/client/services/interviewers/interviewerSupport';
 
 import surveySections from '../survey/sections';
 import { widgets as widgetsConfig } from '../survey/widgetsConfigs';
 
-setApplicationConfiguration<EvolutionApplicationConfiguration>({
-    sections: surveySections,
-    widgets: widgetsConfig as any,
-    allowedUrlFields: ['source', 'accessCode'],
-    templateMapping: { ...appConfig.templateMapping, visitedPlaces: VisitedPlaceSection }
-});
+// TODO This is a workaround to get the links to the user, until some more complete solution is implemented (see https://github.com/chairemobilite/transition/issues/1516)
+const pages = appConfig.pages;
+pages.push({ path: '/interviews', permissions: { Interviews: ['read', 'update'] }, title: 'customLabel:Interviewers' });
+
+setApplicationConfiguration<EvolutionApplicationConfiguration>(
+    addInterviewerOptions({
+        sections: surveySections,
+        widgets: widgetsConfig as any,
+        allowedUrlFields: ['source', 'accessCode'],
+        templateMapping: { ...appConfig.templateMapping, visitedPlaces: VisitedPlaceSection },
+        pages
+    }) as any
+);
 
 runClientApp();

--- a/survey/src/admin/server/roleDefinitions.ts
+++ b/survey/src/admin/server/roleDefinitions.ts
@@ -1,0 +1,9 @@
+import { addRoleHomePage } from 'chaire-lib-backend/lib/services/auth/userPermissions';
+import setupInterviewerRoleDefinition from 'evolution-interviewer/lib/server/services/auth/roleDefinition';
+
+// Add the interviewer roles definition and set the admin's page to /admin
+export default () => {
+    setupInterviewerRoleDefinition();
+
+    addRoleHomePage('admin', '/admin');
+};

--- a/survey/src/admin/serverAdmin.ts
+++ b/survey/src/admin/serverAdmin.ts
@@ -11,13 +11,15 @@ import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
 import serverUpdateCallbacks from '../survey/server/serverFieldUpdate';
 import serverValidations from '../survey/server/serverValidations';
+import roleDefinitions from './server/roleDefinitions';
 
 // TODO Add validation list filter if necessary
 
 const configureServer = () => {
     setProjectConfig({
         serverUpdateCallbacks,
-        serverValidations
+        serverValidations,
+        roleDefinitions
     });
 };
 


### PR DESCRIPTION
fixes #129

This adds the interviewer roles, as well as the interviewer's page that links to the list of surveys that interviewers can use to search for access codes and create new interviews.

This was copied directly from od_nationale_2024