### PR TITLE
auth page: remove the header text

### DIFF
--- a/survey/locales/en/survey.yaml
+++ b/survey/locales/en/survey.yaml
@@ -133,6 +133,7 @@ auth:
         Note that if you proceed without an email, you won't be able to come
         back to the survey if your session expires.
     Login: Confirm
+    AuthMainIntroduction: ''
 visitedPlace:
     activities:
         accompanySomeone: Accompany someone

--- a/survey/locales/fr/survey.yaml
+++ b/survey/locales/fr/survey.yaml
@@ -154,6 +154,7 @@ auth:
         votre questionnaire si votre session expire ou si vous changez de
         navigateur.
     Login: Confirmer
+    AuthMainIntroduction: ''
 visitedPlace:
     departurePlaceIsRequiredError: Le point de départ est requis.
     activities:


### PR DESCRIPTION
fixes #247

This text only makes sense if there is more than 1 auth method, which is not the case here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded localization by adding new translation entries for the authentication introduction in English and French. No user-visible changes yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->