### PR TITLE
update consentement and faq

### DIFF
--- a/survey/locales/en/survey.yaml
+++ b/survey/locales/en/survey.yaml
@@ -4,7 +4,7 @@ homepage:
         processing, and use of the personal information provided during the
         Survey.
     ErrorNotAgreed: In order to start the survey, you must accept the terms of use.
-    introduction_sherbrooke: >-
+    introduction_saguenay: >-
         <p class="left">The <span class="_strong">Origin-Destination
         Survey</span> is underway and your participation is important for its
         success. </p><p class="left">You are invited to describe your trips as
@@ -12,9 +12,9 @@ homepage:
         is suggested to you.</p><br/><details style="margin-bottom:
         1rem"><summary class="left _strong" style="cursor: pointer;">Consent for
         the Transmission of Personal Information</summary><ul><li>As part of the
-        2024 Sherbrooke Origin-Destination Survey (the "Survey"), I authorize
+        2025 Saguenay Origin-Destination Survey (the "Survey"), I authorize
         the Ministère des Transports et de la Mobilité durable (MTMD), the
-        Société de transport de Sherbrooke, and the city of Sherbrooke (the
+        Société de transport du Saguenay, and the city of Saguenay (the
         "Organizations") to collect the following personal
         information:<ul><li>Email address.</li><li>Home address.</li><li>Your
         household profile: location, number of people, number of available
@@ -35,7 +35,7 @@ homepage:
         Organizations</li><li>Recognized educational institutions and research
         centres</li></ul></li><li>If you choose not to continue with the Survey,
         the personal information collected up to that point will be
-        destroyed.</li><li>Anyone who has provided personal information by
+        destroyed at your request.</li><li>Anyone who has provided personal information by
         participating in the Survey has the right to access their personal
         information held about them, obtain a copy, or request correction of
         inaccurate, incomplete, ambiguous, or unlawfully collected information
@@ -43,14 +43,14 @@ homepage:
         Ministère des Transports de la Mobilité durable at 418 646-0160,
         extension 23013, or by sending a written request with proof of identity
         to <a
-        href="mailto:lai@transports.gouv.qc.ca">lai@transports.gouv.qc.ca</a>.</li><li>Personal
+        href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a>.</li><li>Personal
         information will be retained for a period determined by the
-        Organizations' retention schedule.</li><li>If you refuse to provide the
+        MTMD's retention schedule.</li><li>If you refuse to provide the
         required personal information for the Survey, you will not be able to
-        participate.</li></ul><br/><p class="left">You must also consent to this
-        form from Polytechnique Montreal: <a
-        href="/dist/documents/C-FIC_SondageWeb_EN_EnqueteOrigineDestination2024_V2.pdf"
-        target="_blank">Information and consent form</a></p></details>
+        participate.</li></ul><br/><p class="left">For more information about the Survey, please visit the following link : <a
+        href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
+        target="_blank">Enquêtes origine-destination - Transports et Mobilité
+        durable Québec (gouv.qc.ca)</a>.</p></details>
     introduction: >-
         <p class="left">The <span class="_strong">Origin-Destination
         Survey</span> is underway and your participation is important for its
@@ -59,7 +59,7 @@ homepage:
         is suggested to you.</p><br/><details style="margin-bottom:
         1rem"><summary class="left _strong" style="cursor: pointer;">Consent for
         the Transmission of Personal Information</summary><ul><li>As part of the
-        2024 Origin-Destination Survey (the "Survey"), I authorize the Ministère
+        2025 Origin-Destination Survey (the "Survey"), I authorize the Ministère
         des Transports et de la Mobilité durable (MTMD) to collect the following
         personal information:<ul><li>Email address.</li><li>Home
         address.</li><li>Your household profile: location, number of people,
@@ -80,7 +80,7 @@ homepage:
         are:<ul><li>MTMD.</li><li>Recognized educational institutions and
         research centres.</li></ul></li><li>If you choose not to continue with
         the Survey, the personal information collected up to that point will be
-        destroyed.</li><li>Anyone who has provided personal information by
+        destroyed at your request.</li><li>Anyone who has provided personal information by
         participating in the Survey has the right to access their personal
         information held about them, obtain a copy, or request correction of
         inaccurate, incomplete, ambiguous, or unlawfully collected information
@@ -88,33 +88,47 @@ homepage:
         Ministère des Transports et de la Mobilité durable at 418 646-0160,
         extension 23013, or by sending a written request with proof of identity
         to <a
-        href="mailto:lai@transports.gouv.qc.ca">lai@transports.gouv.qc.ca</a>.</li><li>Personal
+        href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a>.</li><li>Personal
         information will be retained for a period determined by MTMD's retention
         schedule.</li><li>If you refuse to provide the required personal
         information for the Survey, you will not be able to
         participate.</li></ul><br/><p class="left">You must also consent to this
         form from Polytechnique Montreal: <a
         href="/dist/documents/C-FIC_SondageWeb_EN_EnqueteOrigineDestination2024_V2.pdf"
-        target="_blank">Information and consent form</a></p></details>
+        target="_blank">Information and consent</a></p></details>
     introductionParagraphTwo: >-
         <p class="left">We thank you for your contribution to the planning of
         tomorrow's transportation!</p><br/> <p class="left _strong"
         style="margin-bottom: 1rem;">The deadline to participate is December
-        16th, 2024.</p><br/><p class="left"><em>For more information about the
+        16th, 2025.</p><br/><p class="left"><em>For more information about the
         Survey, please visit the following link</em>: <a
         href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
         target="_blank">Enquêtes origine-destination - Transports et Mobilité
         durable Québec (gouv.qc.ca)</a>.</em></p><p class="center _oblique"
-        style="margin: 2rem 0;"><a href="mailto:eod@transports.gouv.qc.ca"
+        style="margin: 2rem 0;"><a href="mailto:EOD@transports.gouv.qc.ca"
         target="_blank">Contact us</a></p>
     start: Start
 footer: >-
     <div style="display: flex;justify-content: center;"><div style="font-size:
     80%;max-width: 700px;margin: 15px;"><p><a
     href="/dist/documents/demo_information_consent_form.pdf"
-    target="_blank">Information and Consent Form</a> | <a
-    href="mailto:mobilite@polymtl.ca?subject=Demo%20Survey"
+    target="_blank">Information and Consent</a> | <a
+    href="mailto:EOD@transports.gouv.qc.ca?subject=Origin-Destination%20Survey"
     target="_blank">Contact us by email</a></p></div></div>
+    <details class="faq-container"><summary class="faq-title">Frequently Asked Questions
+    (FAQ)</summary><details><summary class="_h2">What is an Origin-Destination (OD) Survey?</summary><h3>Planning
+    for Tomorrow's Transport</h3><p>A large-scale survey aimed at collecting precise and factual information about the travel patterns of residents in the surveyed territory.</p><h3>Collecting Information</h3><p>This information is an essential resource for public organizations seeking to improve and develop current and future infrastructure and transport.</p><h3>Participation</h3><p>Household participation is fundamental to the success of this survey. The data collected will allow for the comparison and analysis of mobility trends over the years.</p></details><details><summary
+    class="_h2">Who is conducting the survey?</summary><p>The survey is conducted by the Ministère des Transports et de la Mobilité durable (MTMD) and its partners.</p></details><details><summary
+    class="_h2">How is the survey conducted?</summary><p>Households will receive an invitation in the mail to complete the online questionnaire.</p></details><details><summary
+    class="_h2">Why is the survey taking place in the fall?</summary><p>Travel habits are generally more stable in the fall or spring. For a survey of this scale, the fall period is long enough to achieve the desired number of interviews.</p></details><details><summary
+    class="_h2">Why does the survey span several weeks?</summary><p>The survey duration needs to be long enough to meet sampling objectives. This ensures that the diversity of daily travel patterns in the survey area is accurately represented. To maintain representativeness, days affected by certain events, such as public holidays, general elections, or public service strikes, are excluded.</p></details><details><summary class="_h2">Is the survey representative of reality?</summary><p>To ensure result representativeness, the survey area is divided into sectors, each with its own questionnaire completion goal. The resulting profile will be statistically representative of the behaviours of all households in the area.</p></details><details><summary class="_h2">Can everyone participate in the survey?</summary><p>To ensure the representativeness of the survey results, only households that are directly invited can participate.</p></details><details><summary class="_h2">What is the participant selection process?</summary><p>The only selection criterion for households is geographic. Households are randomly selected from the Adresses Québec and DGEQ (Directeur général des élections) lists.</p></details><details><summary class="_h2">Is participation in the survey mandatory?</summary><p>Invited households participate on a voluntary basis. A high response rate will ensure the success of the OD survey, an important tool to facilitate the planning of infrastructure and mobility services in the area.</p></details><details><summary
+    class="_h2">Is the information disclosed by residents confidential and protected?</summary><p>The confidentiality and protection of the information collected are ensured by highly restricted and secure access to the databases. Security certificates are installed on the server, and data transmitted is encrypted at each stage.</p><p>No personal information, such as phone numbers, will be kept in the final database. The collected data is analyzed then published in aggregated form (grouped data). It will be used solely for mobility analysis for transport and land use planning within public agencies and organizations. Any public disclosure of survey data is subject to the Act respecting Access to documents held by public bodies and the Protection of personal information.</p><p>Additionally, survey personnel are bound by professional secrecy. Firms contracted to collect data have signed confidentiality agreements regarding any personal and identifying information they access. These firms will lose access to the databases once their mandate is completed.</p></details><details><summary
+    class="_h2">Does the survey favour one mode of transportation over another?</summary><p>No, the survey aims to understand all travel habits of residents. The data will be used to identify transport needs, regardless of the mode of transportation used. There is no bias towards any particular mode of transportation, nor any value judgment. The goal is to obtain a profile that closely resembles the observed behaviours.</p></details><h2
+    style="margin-top: 2rem;">2025 Origin-Destination Surveys</h2><details><summary
+    class="_h2">How does data collection work?</summary><p>Information about each household will be collected through an online questionnaire. The administration of the online questionnaires will be managed via the Evolution platform, under an agreement with the École Polytechnique de Montréal.</p></details><details><summary
+    class="_h2">What is asked of participating households?</summary><p>The survey questions focus on three aspects:</p><ul><li>Household profile: location, number of people, number of available vehicles, income category, housing status, presence of individuals with mobility limitations due to permanent disability;</li><li>Profile of each household member: age, gender, whether they have a driver's licence, whether they have a public transit pass, whether they subscribe to a car-sharing service, occupation, where they work/study, remote work/study habits;</li><li>Travel profile of each household member (i.e., information about each trip made on the day prior to opening the questionnaire): purpose, departure time, origin and destination, modes of transportation used, and if applicable, public transit lines used, where they changed modes of transportation, and workplace parking.</li></ul></details><details><summary
+    class="_h2">In the questionnaire, I need to report my travel for a specific day, but this day is not representative of my daily travel.</summary><p>The goal of the survey is to understand the travel practices of the entire community during an average weekday. It is normal and statistically acceptable to have a subset of respondents whose travel on the surveyed day may be more or less representative of their usual travel. It is important to describe what you actually did.</p></details><details><summary class="_h2">I received an invitation in the mail to complete the online questionnaire. Can I get assistance?</summary><p>Yes, assistance is available. Residents invited to participate in the online survey can contact us by email at <a href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a>.</p></details><details><summary
+    class="_h2">Why are you asking for so many details?</summary><p>The goal is to get an accurate description of the trips made. To do this, knowing the locations of origin and destination is necessary. The more precise the location, the more detailed the analysis can be. Details of each individual trip is needed to understand certain phenomena, such as which mode of transportation is chosen for a trip. However, all results are presented in aggregated data form.</p></details></details>'
 auth:
     EmailSubLabel: >-
         <br /><span class="_pale _oblique">In case of disconnection, you can

--- a/survey/locales/fr/survey.yaml
+++ b/survey/locales/fr/survey.yaml
@@ -6,7 +6,7 @@ homepage:
     ErrorNotAgreed: >-
         Vous devez accepter les conditions d'utilisation pour débuter le
         questionnaire.
-    introduction_sherbrooke: >-
+    introduction_saguenay: >-
         <p class="left"><span class="_strong">L'enquête
         Origine-Destination</span> est en cours et votre participation est
         importante pour sa réussite.</p><p class="left">Vous êtes invités à
@@ -15,14 +15,14 @@ homepage:
         1rem"><summary class="left _strong" style="cursor:
         pointer;">Consentement à la transmission de renseignements
         personnels</summary><ul><li>Dans le cadre de l'Enquête
-        origine-destination 2024 de Sherbrooke (l'«Enquête»), j'autorise le
+        origine-destination 2025 de Saguenay (l'«Enquête»), j'autorise le
         ministère des Transports et de la Mobilité durable, la Société de
-        transport de Sherbrooke et la Ville de Sherbrooke (les «Organismes») à
+        transport du Saguenay et la Ville de Saguenay (les «Organismes») à
         collecter les renseignements personnels suivants :<ul><li>adresse
         courriel;</li><li>adresse du domicile;</li><li>profil du ménage :
-        localisation, nombre de personnes, nombre de véhicules à disposition,
-        catégorie de revenu, mode d'occupation, présence de personnes limitées
-        dans leurs déplacements quotidiens en raison d'une
+        localisation, nombre de personnes, nombre de véhicules à leur
+        disposition, catégorie de revenu, mode d'occupation, présence de
+        personnes limitées dans leurs déplacements quotidiens en raison d'une
         incapacité;</li><li>profil de chacune des personnes composant le ménage
         : âge, sexe, possession d'un permis de conduire, possession d'un
         laissez-passer de transport en commun, abonnement à un service
@@ -41,7 +41,7 @@ homepage:
         Organismes;</li><li>Les établissements d'enseignement et les centres de
         recherche reconnus.</li></ul></li><li>Si au cours de l'Enquête, vous ne
         désirez plus poursuivre, les renseignements personnels recueillis
-        jusqu'à ce moment seront détruits.</li><li>Toute personne ayant fourni
+        jusqu'à ce moment seront détruits à votre demande.</li><li>Toute personne ayant fourni
         des renseignements personnels en participant à l'Enquête a le droit de
         consulter les renseignements personnels détenus à son sujet, d'en
         obtenir copie ou de requérir la rectification des renseignements
@@ -49,16 +49,17 @@ homepage:
         loi. Pour ce faire, elle doit contacter le responsable de l'accès à
         l'information du ministère des Transports et de la Mobilité durable au
         418 646-0160, poste 23013, ou lui adresser une demande écrite à <a
-        href="mailto:lai@transports.gouv.qc.ca">lai@transports.gouv.qc.ca</a> en
+        href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a> en
         prouvant son identité.</li><li>Les renseignements personnels seront
         conservés durant un délai déterminé au moyen du calendrier de
         conservation des Organismes.</li><li>Si vous refusez de fournir les
         renseignements personnels requis dans le cadre de l'Enquête, vous ne
-        pourrez pas y participer.</li></ul><br/><p class="left">Vous devez
-        également consentir au formulaire suivant de Polytechnique Montréal: <a
-        href="/dist/documents/C-FIC_SondageWeb_FR_EnqueteOrigineDestination2024_V2.pdf"
-        target="_blank">Formulaire d’information et de
-        consentement</a></p></details>
+        pourrez pas y participer.</li></ul><br/><p class="left">Pour obtenir plus
+        d'information sur l'Enquête, nous vous invitons à consulter la page
+        suivante: <a
+        href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
+        target="_blank">Enquêtes origine-destination - Transports et Mobilité
+        durable Québec (gouv.qc.ca)</a>.</p></details>
     introduction: >-
         <p class="left"><span class="_strong">L'enquête
         Origine-Destination</span> est en cours et votre participation est
@@ -68,7 +69,7 @@ homepage:
         1rem"><summary class="left _strong" style="cursor:
         pointer;">Consentement à la transmission de renseignements
         personnels</summary><ul><li>Dans le cadre de l'Enquête
-        origine-destination 2024 (l'«Enquête»), j'autorise le ministère des
+        Origine-Destination 2025 (l'«Enquête»), j'autorise le ministère des
         Transports et de la Mobilité durable (MTMD) à collecter les
         renseignements personnels suivants :<ul><li>adresse
         courriel;</li><li>adresse du domicile;</li><li>profil du ménage :
@@ -93,7 +94,7 @@ homepage:
         d'enseignement et les centres de recherche
         reconnus.</li></ul></li><li>Si au cours de l'Enquête, vous ne désirez
         plus poursuivre, les renseignements personnels recueillis jusqu'à ce
-        moment seront détruits.</li><li>Toute personne ayant fourni des
+        moment seront détruits à votre demande.</li><li>Toute personne ayant fourni des
         renseignements personnels en participant à l'Enquête a le droit de
         consulter les renseignements personnels détenus à son sujet, d'en
         obtenir copie ou de requérir la rectification des renseignements
@@ -101,37 +102,138 @@ homepage:
         loi. Pour ce faire, elle doit contacter le responsable de l'accès à
         l'information du ministère des Transports et de la Mobilité durable au
         418 646-0160, poste 23013, ou lui adresser une demande écrite à <a
-        href="mailto:lai@transports.gouv.qc.ca">lai@transports.gouv.qc.ca</a> en
+        href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a> en
         prouvant son identité.</li><li>Les renseignements personnels seront
         conservés durant un délai déterminé au moyen du calendrier de
         conservation du MTMD.</li><li>Si vous refusez de fournir les
         renseignements personnels requis dans le cadre de l'Enquête, vous ne
-        pourrez pas y participer.</li></ul><br/><p class="left">Vous devez
-        également consentir au formulaire suivant de Polytechnique Montréal: <a
-        href="/dist/documents/C-FIC_SondageWeb_FR_EnqueteOrigineDestination2024_V2.pdf"
-        target="_blank">Formulaire d’information et de
-        consentement</a></p></details>
+        pourrez pas y participer.</li></ul><br/><p class="left">Pour obtenir plus
+        d'information sur l'Enquête, nous vous invitons à consulter la page
+        suivante: <a
+        href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
+        target="_blank">Enquêtes origine-destination - Transports et Mobilité
+        durable Québec (gouv.qc.ca)</a>.</p></details>
     introductionParagraphTwo: >-
         <p class="left">Nous vous remercions pour votre contribution à la
         planification du transport de demain!</p><br/><p class="left _strong"
         style="margin-bottom: 1rem;">La date limite pour participer est le 16
-        décembre 2024.</p><br/><p class="left"><em>Pour obtenir plus
+        décembre 2025.</p><br/><p class="left"><em>Pour obtenir plus
         d'information sur l'Enquête, nous vous invitons à consulter la page
-        suivante</em> : <a
+        suivante</em>: <a
         href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
         target="_blank">Enquêtes origine-destination - Transports et Mobilité
         durable Québec (gouv.qc.ca)</a>.</em></p><br/> <p class="center
         _oblique" style="margin: 2rem 0;"><a
-        href="mailto:eod@transports.gouv.qc.ca" target="_blank">Nous
+        href="mailto:EOD@transports.gouv.qc.ca" target="_blank">Nous
         joindre</a></p>
     start: Débuter
 footer: >-
     <div style="display: flex;justify-content: center;"><div style="font-size:
     80%;max-width: 700px;margin: 15px;"><p><a
     href="/dist/documents/demo_information_consent_form.pdf"
-    target="_blank">Formulaire d’information et de consentement</a>&nbsp;| <a
-    href="mailto:mobilite@polymtl.ca?subject=Questionnaire%20de%20démonstration"
-    target="_blank">Nous joindre par courriel</a></p>
+    target="_blank">Information de consentement</a>&nbsp;| <a
+    href="mailto:EOD@transports.gouv.qc.ca?subject=Enquête%20Origine-Destination"
+    target="_blank">Nous joindre par courriel</a></p></div></div>
+    <details class="faq-container"><summary class="faq-title">Foire aux questions
+    (FAQ)</summary><details><summary class="_h2">Qu'est-ce qu'une EOD?</summary><h3>Planifier
+    le transport de demain</h3><p>Enquête d'envergure qui vise à recueillir des renseignements
+    précis et factuels sur les déplacements des résidents des territoires d'enquêtes
+    concernés.</p><h3>Recueillir l'information</h3><p>Ces renseignements constituent
+    une source d'information indispensable pour les organismes publics travaillant
+    à l'amélioration et au développement du territoire et des transports actuels et
+    futurs.</p><h3>La participation</h3><p>La participation des citoyens est fondamentale
+    pour la réussite de cette enquête. Les données ainsi recueillies permettront de
+    comparer et d'analyser les tendances en matière de mobilité au fil des ans.</p></details><details><summary
+    class="_h2">Qui réalise cette enquête?</summary><p>Cette enquête est réalisée par
+    le ministère des Transports et de la Mobilité durable (MTMD) et ses partenaires.</p></details><details><summary
+    class="_h2">Comment cette enquête est-elle réalisée?</summary><p>Les ménages recevront
+    une invitation postale pour remplir le questionnaire en ligne.</p></details><details><summary
+    class="_h2">Pourquoi l'enquête a-t-elle lieu à l'automne?</summary><p>Les habitudes
+    de déplacement de la population sont généralement plus stables à l'automne ou au
+    printemps. Pour une enquête de l'envergure de celle-ci, seule la période de l'automne
+    est suffisamment longue pour réaliser le nombre d'entrevues visé.</p></details><details><summary
+    class="_h2">Pourquoi l'enquête s'échelonne-t-elle sur plusieurs semaines?</summary><p>La
+    durée de l'enquête doit être suffisamment longue pour atteindre les objectifs d'échantillonnage.
+    Ainsi, la diversité des déplacements effectués quotidiennement par la population
+    de la région faisant l'objet de l'enquête pourra être justement représentée. Toujours
+    pour assurer la représentativité optimale, les journées où certaines situations
+    influencent la nature ou le nombre de déplacements sont exclues. Pensons aux jours
+    fériés, aux journées d'élections générales ou aux périodes de grève des services
+    publics.</p></details><details><summary class="_h2">L'enquête est-elle représentative
+    de la réalité?</summary><p>Pour assurer la représentativité des résultats, le territoire
+    d'enquête est divisé en secteurs ayant chacun un objectif quant au nombre de questionnaires
+    à remplir. Le portrait obtenu sera ainsi statistiquement représentatif des comportements
+    de l'ensemble des ménages qui y habitent.</p></details><details><summary class="_h2">Est-ce
+    que tout le monde peut participer à l'enquête?</summary><p>Pour assurer la représentativité
+    des résultats de l'enquête, seuls les ménages directement invités peuvent participer
+    à l'enquête.</p></details><details><summary class="_h2">Quel est le processus de
+    sélection des participants?</summary><p>Le seul critère de sélection des ménages
+    est d'ordre géographique. Les ménages sont sélectionnés de façon aléatoire à partir
+    des listes d'Adresses Québec et du DGEQ (Directeur général des élections).</p></details><details><summary class="_h2">Est-ce
+    que la participation à l'enquête est obligatoire?</summary><p>Les ménages invités
+    répondent sur une base volontaire. La réponse positive du plus grand nombre assurera
+    la réussite de l'EOD, un outil important pour mieux planifier l'aménagement des
+    infrastructures et des services de mobilité sur le territoire.</p></details><details><summary
+    class="_h2">Les renseignements divulgués par les citoyens sont-ils confidentiels
+    et protégés?</summary><p>La confidentialité et la protection des renseignements
+    recueillis dans le cadre de l'enquête sont assurées par des accès très restreints
+    et hautement sécurisés aux bases de données. Des certificats de sécurité sont installés
+    sur le serveur et les données transmises sont cryptées à chaque étape.</p><p>Aucune
+    information nominative, telle que les numéros de téléphone, ne sera conservée dans
+    la base de données finale. Les données recueillies sont analysées, pour être ensuite
+    publiées de façon agrégée (données regroupées). Elles serviront uniquement à des
+    analyses de mobilité pour la planification des transports et de l'aménagement du
+    territoire au sein d'agences et d'organismes publics. Toute disposition visant
+    à fournir au public des renseignements concernant les données de l'enquête est
+    assujettie à la Loi sur l'accès aux documents des organismes publics et sur la
+    protection des renseignements personnels.</p><p>De plus, le personnel affecté à
+    l'enquête est tenu au secret professionnel. Les firmes mandatées pour la collecte
+    des données ont signé un formulaire d'engagement à la confidentialité à l'égard
+    de tout renseignement nominatif et personnel auquel elles ont accès. Ces firmes
+    perdront l'accès aux bases de données au terme de leur mandat.</p></details><details><summary
+    class="_h2">Cette enquête vise-t-elle à privilégier un moyen de transport au détriment
+    d'un autre?</summary><p>Non. Cette enquête a pour but de connaître l'ensemble
+    des habitudes de déplacement des résidents. L'utilisation des données vise à identifier
+    les besoins en transport, quel que soit le moyen de transport utilisé. Il n'y a
+    aucun parti pris pour un mode de transport ni aucun jugement de valeur. L'objectif
+    est d'obtenir un portrait qui s'apparente le plus possible aux comportements observés.</p></details><h2
+    style="margin-top: 2rem;">Enquêtes origine-destination 2025</h2><details><summary
+    class="_h2">Comment fonctionne la collecte de données?</summary><p>Les renseignements
+    des ménages sont collectés au moyen d'un questionnaire en ligne. La réalisation
+    des questionnaires en ligne sera administrée au moyen de la plateforme Évolution,
+    dans le cadre d'une entente avec Polytechnique Montréal.</p></details><details><summary
+    class="_h2">Que demande-t-on aux ménages participant à l'enquête?</summary><p>Les
+    questions de l'enquête portent particulièrement sur les trois aspects suivants
+    :</p><ul><li>le profil du ménage - localisation, nombre de personnes, nombre de
+    véhicules à sa disposition, catégorie de revenu, mode d'occupation du logement,
+    présence de personnes limitées dans leurs déplacements quotidiens en raison d'une
+    incapacité permanente;</li><li>le profil de chacune des personnes composant le ménage
+    - âge, sexe, possession d'un permis de conduire, possession d'un laissez-passer
+    de transport en commun, abonnement à un service d'autopartage, l'occupation, localisation
+    du lieu de travail ou d'études, habitudes de télétravail ou de téléétudes;</li><li>le
+    profil des déplacements de chacune des personnes du ménage (renseignements sur chacun
+    des déplacements effectués une journée précédant le jour de l'ouverture du questionnaire)
+    - motif, heure de départ, lieux d'origine et de destination, modes de transport
+    utilisés et, le cas échéant, lignes de transport en commun utilisées, lieu du changement
+    de mode de transport et stationnement au lieu de travail.</li></ul></details><details><summary
+    class="_h2">Dans le questionnaire, je dois indiquer mes déplacements pour une journée
+    particulière, mais cette journée n'est pas représentative de mes déplacements quotidiens.</summary><p>L'objectif
+    de l'enquête est de connaître les pratiques de déplacement de l'ensemble de la
+    communauté pendant un jour moyen de semaine. Il est normal et tout à fait acceptable,
+    sur le plan statistique, d'avoir un sous-ensemble de répondants dont les déplacements
+    effectués lors de la journée ciblée ont été plus ou moins représentatifs de leurs
+    déplacements habituels. Il est important de décrire ce que vous avez réellement
+    fait.</p></details><details><summary class="_h2">J'ai été sollicité par la poste
+    pour répondre au questionnaire en ligne. Puis-je avoir de l'assistance?</summary><p>Oui,
+    c'est possible. Les résidents invités à participer à l'enquête en ligne peuvent
+    communiquer avec nous par courriel à l'adresse suivante: <a href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a>.</p></details><details><summary
+    class="_h2">Pourquoi demandez-vous des renseignements aussi précis?</summary><p>L'objectif
+    est de connaître avec précision les déplacements effectués. Pour ce faire, la localisation
+    des lieux d'origine et de destination est nécessaire. Plus cette localisation est
+    précise, plus l'analyse produite est fine. La précision des déplacements de chaque
+    individu est nécessaire pour bien comprendre certains phénomènes comme, notamment,
+    le choix modal retenu pour réaliser le déplacement. Lors de la diffusion cependant,
+    le résultat est présenté sous forme de données agrégées.</p></details></details>'
 auth:
     EmailSubLabel: >-
         <br /><span class="_pale _oblique">En cas de déconnexion, vous pourrez

--- a/survey/references/consentement_od_nationale_2025_fr_en.md
+++ b/survey/references/consentement_od_nationale_2025_fr_en.md
@@ -1,0 +1,136 @@
+**CONSENTEMENT À LA TRANSMISSION DE RENSEIGNEMENTS PERSONNELS**
+
+1.  **Dans le cadre de l'Enquête Origine-Destination 2025
+    (l'« Enquête »), j'autorise le ministère des Transports et de la
+    Mobilité durable (MTMD) à collecter les renseignements personnels
+    suivants :**
+
+    A.  **adresse courriel;**
+
+    B.  **adresse du domicile;**
+
+    C.  **profil du ménage : localisation, nombre de personnes, nombre
+        de véhicules à disposition, catégorie de revenu, mode
+        d'occupation, présence de personnes limitées dans leurs
+        déplacements quotidiens en raison d'une incapacité;**
+
+    D.  **profil de chacune des personnes composant le ménage : âge,
+        sexe, possession d'un permis de conduire, possession d'un
+        laissez-passer de transport en commun, abonnement à un service
+        d'autopartage, situation d'emploi, localisation du lieu de
+        travail ou d'études, habitudes de télétravail ou de
+        téléétudes;**
+
+    E.  **profil des déplacements de chacune des personnes du ménage
+        lors d'une journée en particulier.**
+
+1.  **Les renseignements personnels recueillis durant l'Enquête
+    permettent au MTMD de bien comprendre les besoins de la population
+    en transport et ainsi de planifier les futures interventions en
+    matière d'offre routière et de transport collectif.**
+
+2.  **Les renseignements personnels seront collectés au moyen d'un
+    questionnaire en ligne.**
+
+3.  **Votre participation à l'Enquête est sur une base volontaire.**
+
+4.  **Les catégories de personnes qui pourront, dans l'exercice de leurs
+    fonctions, avoir accès à ces renseignements personnels sont :**
+
+    a.  **MTMD;**
+
+    b.  **Les établissements d'enseignement et les centres de recherche
+        reconnus.**
+
+1.  **Si au cours de l'Enquête, vous ne désirez plus poursuivre, les
+    renseignements personnels recueillis jusqu'à ce moment seront
+    détruits à votre demande.**
+
+2.  **Toute personne ayant fourni des renseignements personnels en
+    participant à l'Enquête a le droit de consulter les renseignements
+    personnels détenus à son sujet, d'en obtenir copie ou de requérir la
+    rectification des renseignements inexacts, incomplets, équivoques ou
+    recueillis en contravention de la loi. Pour ce faire, elle doit
+    contacter le responsable de l'accès à l'information du ministère des
+    Transports et de la Mobilité durable au 418 646-0160, poste 23013,
+    ou lui adresser une demande écrite à EOD@transports.gouv.qc.ca en
+    prouvant son identité.**
+
+3.  **Les renseignements personnels seront conservés durant un délai
+    déterminé au moyen du calendrier de conservation du MTMD.**
+
+4.  **Si vous refusez de fournir les renseignements personnels requis
+    dans le cadre de l'Enquête, vous ne pourrez pas y participer.**
+
+Pour obtenir plus d'information sur l'Enquête, nous vous invitons à
+consulter la page suivante: https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx.
+
+**Je confirme avoir lu ce qui précède et consens à la collecte, au
+traitement et à l'utilisation des renseignements personnels transmis
+lors de l'Enquête.**
+
+**Version anglaise:**
+
+**Consent for the Transmission of Personal Information**
+
+1.  **As part of the 2025 Origin-Destination Survey (the "Survey"), I
+    authorize the Ministère des Transports et de la Mobilité durable
+    (MTMD) to collect the following personal information:**
+
+**A. Email address.**
+
+**B. Home address.**
+
+**C. Your household profile: location, number of people, number of
+available vehicles, income category, housing status, presence of
+individuals with mobility limitations due to disability.**
+
+**D. Profile of each member of your household: age, gender, whether they
+have a driver's licence, whether they have a public transit pass,
+whether they subscribe to a car-sharing service, occupation, where they
+work/study, remote work/study habits; and**
+
+**E. Travel profile of each member of your household on a specific
+day.**
+
+1.  **The personal information collected during the Survey allows the
+    MTMD to understand the transportation needs of the population and to
+    plan future road infrastructure and public transport projects.**
+
+2.  **The personal information will be collected through an online
+    questionnaire.**
+
+3.  **Your participation in the Survey is voluntary.**
+
+4.  **The categories of individuals who may have access to this personal
+    information in the course of their duties are:**
+
+**a. MTMD.**
+
+**b. Recognized educational institutions and research centres.**
+
+1.  **If you choose not to continue with the Survey, the personal
+    information collected up to that point will be destroyed at your
+    request.**
+
+2.  **Anyone who has provided personal information by participating in
+    the Survey has the right to access their personal information held
+    about them, obtain a copy, or request correction of inaccurate,
+    incomplete, ambiguous, or unlawfully collected information by
+    contacting the person responsible for information access at the
+    Ministère des Transports et de la Mobilité durable at 418 646-0160,
+    extension 23013, or by sending a written request with proof of
+    identity [EOD@transports.gouv.qc.ca].**
+
+3.  **Personal information will be retained for a period determined by
+    MTMD's retention schedule.**
+
+4.  **If you refuse to provide the required personal information for the
+    Survey, you will not be able to participate.**
+
+***For more information about the Survey, please visit the following
+link*: https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx.**
+
+**I confirm that I have read the above and consent to the collection,
+processing, and use of the personal information provided during the
+Survey.**

--- a/survey/references/consentement_od_saguenay_2025_fr_en.md
+++ b/survey/references/consentement_od_saguenay_2025_fr_en.md
@@ -1,0 +1,139 @@
+**CONSENTEMENT À LA TRANSMISSION DE RENSEIGNEMENTS PERSONNELS**
+
+1.  **Dans le cadre de l'Enquête Origine-Destination 2025
+    (l'« Enquête »), j'autorise le ministère des Transports et de la
+    Mobilité durable (MTMD), la ville de Saguenay et la société de
+    transport du Saguenay (les «Organismes») à collecter les
+    renseignements personnels suivants :**
+
+    A.  **adresse courriel;**
+
+    B.  **adresse du domicile;**
+
+    C.  **profil du ménage : localisation, nombre de personnes, nombre
+        de véhicules à disposition, catégorie de revenu, mode
+        d'occupation, présence de personnes limitées dans leurs
+        déplacements quotidiens en raison d'une incapacité;**
+
+    D.  **profil de chacune des personnes composant le ménage : âge,
+        sexe, possession d'un permis de conduire, possession d'un
+        laissez-passer de transport en commun, abonnement à un service
+        d'autopartage, situation d'emploi, localisation du lieu de
+        travail ou d'études, habitudes de télétravail ou de
+        téléétudes;**
+
+    E.  **profil des déplacements de chacune des personnes du ménage
+        lors d'une journée en particulier.**
+
+1.  **Les renseignements personnels recueillis durant l'Enquête
+    permettent au MTMD de bien comprendre les besoins de la population
+    en transport et ainsi de planifier les futures interventions en
+    matière d'offre routière et de transport collectif.**
+
+2.  **Les renseignements personnels seront collectés au moyen d'un
+    questionnaire en ligne.**
+
+3.  **Votre participation à l'Enquête est sur une base volontaire.**
+
+4.  **Les catégories de personnes qui pourront, dans l'exercice de leurs
+    fonctions, avoir accès à ces renseignements personnels sont :**
+
+    a.  **Les organismes;**
+
+    b.  **Les établissements d'enseignement et les centres de recherche
+        reconnus.**
+
+1.  **Si au cours de l'Enquête, vous ne désirez plus poursuivre, les
+    renseignements personnels recueillis jusqu'à ce moment seront
+    détruits à votre demande.**
+
+2.  **Toute personne ayant fourni des renseignements personnels en
+    participant à l'Enquête a le droit de consulter les renseignements
+    personnels détenus à son sujet, d'en obtenir copie ou de requérir la
+    rectification des renseignements inexacts, incomplets, équivoques ou
+    recueillis en contravention de la loi. Pour ce faire, elle doit
+    contacter le responsable de l'accès à l'information du ministère des
+    Transports et de la Mobilité durable au 418 646-0160, poste 23013,
+    ou lui adresser une demande écrite à EOD@transports.gouv.qc.ca en
+    prouvant son identité.**
+
+3.  **Les renseignements personnels seront conservés durant un délai
+    déterminé au moyen du calendrier de conservation du MTMD.**
+
+4.  **Si vous refusez de fournir les renseignements personnels requis
+    dans le cadre de l'Enquête, vous ne pourrez pas y participer.**
+
+Pour obtenir plus d'information sur l'Enquête, nous vous invitons à
+consulter la page suivante: https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx.
+
+**Je confirme avoir lu ce qui précède et consens à la collecte, au
+traitement et à l'utilisation des renseignements personnels transmis
+lors de l'Enquête.**
+
+**Version anglaise:**
+
+**Consent for the Transmission of Personal Information**
+
+1.  **As part of the 2025 Origin-Destination Survey (the "Survey"), I
+    authorize the Ministère des Transports et de la Mobilité durable
+    (MTMD), the City of Saguenay and the société de transport du
+    Saguenay (the \"Organizations\") to collect the following personal
+    information:**
+
+**A. Email address.**
+
+**B. Home address.**
+
+**C. Your household profile: location, number of people, number of
+available vehicles, income category, housing status, presence of
+individuals with mobility limitations due to disability.**
+
+**D. Profile of each member of your household: age, gender, whether they
+have a driver's licence, whether they have a public transit pass,
+whether they subscribe to a car-sharing service, occupation, where they
+work/study, remote work/study habits; and**
+
+**E. Travel profile of each member of your household on a specific
+day.**
+
+1.  **The personal information collected during the Survey allows the
+    MTMD to understand the transportation needs of the population and to
+    plan future road infrastructure and public transport projects.**
+
+2.  **The personal information will be collected through an online
+    questionnaire.**
+
+3.  **Your participation in the Survey is voluntary.**
+
+4.  **The categories of individuals who may have access to this personal
+    information in the course of their duties are:**
+
+**a. The Organizations.**
+
+**b. Recognized educational institutions and research centres.**
+
+1.  **If you choose not to continue with the Survey, the personal
+    information collected up to that point will be destroyed at your
+    request.**
+
+2.  **Anyone who has provided personal information by participating in
+    the Survey has the right to access their personal information held
+    about them, obtain a copy, or request correction of inaccurate,
+    incomplete, ambiguous, or unlawfully collected information by
+    contacting the person responsible for information access at the
+    Ministère des Transports et de la Mobilité durable at 418 646-0160,
+    extension 23013, or by sending a written request with proof of
+    identity [EOD@transports.gouv.qc.ca].**
+
+3.  **Personal information will be retained for a period determined by
+    MTMD's retention schedule.**
+
+4.  **If you refuse to provide the required personal information for the
+    Survey, you will not be able to participate.**
+
+***For more information about the Survey, please visit the following
+link*: .**
+
+**I confirm that I have read the above and consent to the collection,
+processing, and use of the personal information provided during the
+Survey.**

--- a/survey/references/faq_fr_en.md
+++ b/survey/references/faq_fr_en.md
@@ -1,0 +1,322 @@
+**Qu'est-ce qu'une EOD?**
+
+PLANIFIER LE TRANSPORT DE DEMAIN
+
+Enquête d'envergure qui vise à recueillir des renseignements précis et
+factuels sur les déplacements des résidents des territoires d'enquêtes
+concernés.
+
+RECUEILLIR L'INFORMATION
+
+Ces renseignements constituent une source d'information indispensable
+pour les organismes publics travaillant à l'amélioration et au
+développement du territoire et des transports actuels et futurs.
+
+LA PARTICIPATION
+
+La participation des citoyens est fondamentale pour la réussite de cette
+enquête. Les données ainsi recueillies permettront de comparer et
+d'analyser les tendances en matière de mobilité au fil des ans.
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Questions concernant l'EOD**
+
+**Qui réalise cette enquête?**
+
+Cette enquête est réalisée par le ministère des Transports et de la
+Mobilité durable (MTMD) et ses partenaires.
+
+**Comment cette enquête est-elle réalisée?**
+
+Les ménages recevront une invitation postale pour remplir le
+questionnaire en ligne.
+
+**Pourquoi l'enquête a-t-elle lieu à l'automne?**
+
+Les habitudes de déplacement de la population sont généralement plus
+stables à l'automne ou au printemps. Pour une enquête de l'envergure de
+celle-ci, seule la période de l'automne est suffisamment longue pour
+réaliser le nombre d'entrevues visé.
+
+**Pourquoi l'enquête s'échelonne-t-elle sur plusieurs semaines?**
+
+La durée de l'enquête doit être suffisamment longue pour atteindre les
+objectifs d'échantillonnage. Ainsi, la diversité des déplacements
+effectués quotidiennement par la population de la région faisant l'objet
+de l'enquête pourra être justement représentée. Toujours pour assurer la
+représentativité optimale, les journées où certaines situations
+influencent la nature ou le nombre de déplacements sont exclues. Pensons
+aux jours fériés, aux journées d'élections générales ou aux périodes de
+grève des services publics.
+
+**L'enquête est-elle représentative de la réalité?**
+
+Pour assurer la représentativité des résultats, le territoire d'enquête
+est divisé en secteurs ayant chacun un objectif quant au nombre de
+questionnaires à remplir. Le portrait obtenu sera ainsi statistiquement
+représentatif des comportements de l'ensemble des ménages qui y
+habitent.
+
+**Est-ce que tout le monde peut participer à l'enquête?**
+
+Pour assurer la représentativité des résultats de l'enquête, seuls les
+ménages directement invités peuvent participer à l'enquête.
+
+**Quel est le processus de sélection des participants?**
+
+Le seul critère de sélection des ménages est d'ordre géographique. Les
+ménages sont sélectionnés de façon aléatoire à partir des listes
+d'Adresses Québec et du DGEQ (Directeur général des élections).
+
+**Est-ce que la participation à l'enquête est obligatoire?**
+
+Les ménages invités répondent sur une base volontaire. La réponse
+positive du plus grand nombre assurera la réussite de l'EOD, un outil
+important pour mieux planifier l'aménagement des infrastructures et des
+services de mobilité sur le territoire.
+
+**Les renseignements divulgués par les citoyens sont-ils confidentiels
+et protégés?**
+
+La confidentialité et la protection des renseignements recueillis dans
+le cadre de l'enquête sont assurées par des accès très restreints et
+hautement sécurisés aux bases de données. Des certificats de sécurité
+sont installés sur le serveur et les données transmises sont cryptées à
+chaque étape.
+
+Aucune information nominative, telle que les numéros de téléphone, ne
+sera conservée dans la base de données finale. Les données recueillies
+sont analysées, pour être ensuite publiées de façon agrégée (données
+regroupées). Elles serviront uniquement à des analyses de mobilité pour
+la planification des transports et de l'aménagement du territoire au
+sein d'agences et d'organismes publics. Toute disposition visant à
+fournir au public des renseignements concernant les données de l'enquête
+est assujettie à la Loi sur l'accès aux documents des organismes publics
+et sur la protection des renseignements personnels.
+
+De plus, le personnel affecté à l'enquête est tenu au secret
+professionnel. Les firmes mandatées pour la collecte des données ont
+signé un formulaire d'engagement à la confidentialité à l'égard de tout
+renseignement nominatif et personnel auquel elles ont accès. Ces firmes
+perdront l'accès aux bases de données au terme de leur mandat.
+
+**Cette enquête vise-t-elle à privilégier un moyen de transport au
+détriment d'un autre?**
+
+Non. Cette enquête a pour but de connaître l'ensemble des habitudes de
+déplacement des résidents. L'utilisation des données vise à identifier
+les besoins en transport, quel que soit le moyen de transport utilisé.
+Il n'y a aucun parti pris pour un mode de transport ni aucun jugement de
+valeur. L'objectif est d'obtenir un portrait qui s'apparente le plus
+possible aux comportements observés.
+
+**Enquêtes origine-destination 2025**
+
+Les renseignements des ménages sont collectés au moyen d'un
+questionnaire en ligne. La réalisation des questionnaires en ligne sera
+administrée au moyen de la plateforme Évolution, dans le cadre d'une
+entente avec Polytechnique Montréal.
+
+**Que demande-t-on aux ménages participant à l'enquête?**
+
+Les questions de l'enquête portent particulièrement sur les trois
+aspects suivants :
+
+• le profil du ménage -- localisation, nombre de personnes, nombre de
+véhicules à sa disposition, catégorie de revenu, mode d'occupation du
+logement, présence de personnes limitées dans leurs déplacements
+quotidiens en raison d'une incapacité permanente;
+
+• le profil de chacune des personnes composant le ménage -- âge, sexe,
+possession d'un permis de conduire, possession d'un laissez-passer de
+transport en commun, abonnement à un service d'autopartage,
+l'occupation, localisation du lieu de travail ou d'études, habitudes de
+télétravail ou de téléétudes;
+
+• le profil des déplacements de chacune des personnes du ménage
+(renseignements sur chacun des déplacements effectués une journée
+précédant le jour de l'ouverture du questionnaire) -- motif, heure de
+départ, lieux d'origine et de destination, modes de transport utilisés
+et, le cas échéant, lignes de transport en commun utilisées, lieu du
+changement de mode de transport et stationnement au lieu de travail.
+
+**Dans le questionnaire, je dois indiquer mes déplacements pour une
+journée particulière, mais cette journée n'est pas représentative de mes
+déplacements quotidiens.**
+
+L'objectif de l'enquête est de connaître les pratiques de déplacement de
+l'ensemble de la communauté pendant un jour moyen de semaine. Il est
+normal et tout à fait acceptable, sur le plan statistique, d'avoir un
+sous-ensemble de répondants dont les déplacements effectués lors de la
+journée ciblée ont été plus ou moins représentatifs de leurs
+déplacements habituels. Il est important de décrire ce que vous avez
+réellement fait.
+
+**J'ai été sollicité par la poste pour répondre au questionnaire en
+ligne. Puis-je avoir de l'assistance?**
+
+Oui, c'est possible. Les résidents invités à participer à l'enquête en
+ligne peuvent communiquer avec nous par courriel à l'adresse suivante: <a href="mailto:EOD@transports.gouv.qc.ca">EOD@transports.gouv.qc.ca</a>.
+
+**Pourquoi demandez-vous des renseignements aussi précis?**
+
+L'objectif est de connaître avec précision les déplacements effectués.
+Pour ce faire, la localisation des lieux d'origine et de destination est
+nécessaire. Plus cette localisation est précise, plus l'analyse produite
+est fine. La précision des déplacements de chaque individu est
+nécessaire pour bien comprendre certains phénomènes comme, notamment, le
+choix modal retenu pour réaliser le déplacement. Lors de la diffusion
+cependant, le résultat est présenté sous forme de données agrégées.
+
+Version anglaise:
+
+**What is an Origin-Destination (OD) Survey?**
+
+PLANNING FOR TOMORROW'S TRANSPORT
+
+A large-scale survey aimed at collecting precise and factual information
+about the travel patterns of residents in the surveyed territory.
+
+COLLECTING INFORMATION
+
+This information is an essential resource for public organizations
+seeking to improve and develop current and future infrastructure and
+transport.
+
+PARTICIPATION
+
+Household participation is fundamental to the success of this survey.
+The data collected will allow for the comparison and analysis of
+mobility trends over the years.
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Questions About the OD Survey**
+
+**Who is conducting the survey?**
+
+The survey is conducted by the Ministère des Transports et de la
+Mobilité durable (MTMD) and its partners.
+
+**How is the survey conducted?**
+
+Households will receive an invitation in the mail to complete the online
+questionnaire.
+
+**Why is the survey taking place in the fall?**
+
+Travel habits are generally more stable in the fall or spring. For a
+survey of this scale, the fall period is long enough to achieve the
+desired number of interviews.
+
+**Why does the survey span several weeks?**
+
+The survey duration needs to be long enough to meet sampling objectives.
+This ensures that the diversity of daily travel patterns in the survey
+area is accurately represented. To maintain representativeness, days
+affected by certain events, such as public holidays, general elections,
+or public service strikes, are excluded.
+
+**Is the survey representative of reality?**
+
+To ensure result representativeness, the survey area is divided into
+sectors, each with its own questionnaire completion goal. The resulting
+profile will be statistically representative of the behaviours of all
+households in the area.
+
+**Can everyone participate in the survey?**
+
+To ensure the representativeness of the survey results, only households
+that are directly invited can participate.
+
+**What is the participant selection process?**
+
+The only selection criterion for households is geographic. Households
+are randomly selected from the Adresses Québec and DGEQ (Directeur général des élections) list.s
+
+**Is participation in the survey mandatory?**
+
+Invited households participate on a voluntary basis. A high response
+rate will ensure the success of the OD survey, an important tool to
+facilitate the planning of infrastructure and mobility services in the
+area.
+
+**Is the information disclosed by residents confidential and
+protected?**
+
+The confidentiality and protection of the information collected are
+ensured by highly restricted and secure access to the databases.
+Security certificates are installed on the server, and data transmitted
+is encrypted at each stage.
+
+No personal information, such as phone numbers, will be kept in the
+final database. The collected data is analyzed then published in
+aggregated form (grouped data). It will be used solely for mobility
+analysis for transport and land use planning within public agencies and
+organizations. Any public disclosure of survey data is subject to the
+*Act respecting Access to documents held by public bodies and the
+Protection of personal information*.
+
+Additionally, survey personnel are bound by professional secrecy. Firms
+contracted to collect data have signed confidentiality agreements
+regarding any personal and identifying information they access. These
+firms will lose access to the databases once their mandate is completed.
+
+**Does the survey favour one mode of transportation over another?**
+
+No, the survey aims to understand all travel habits of residents. The
+data will be used to identify transport needs, regardless of the mode of
+transportation used. There is no bias towards any particular mode of
+transportation, nor any value judgment. The goal is to obtain a profile
+that closely resembles the observed behaviours.
+
+**2025 Origin-Destination Surveys**
+
+Information about each household will be collected through an online
+questionnaire. The administration of the online questionnaires will be
+managed via the Evolution platform, under an agreement with the École
+Polytechnique de Montréal.
+
+**What is asked of participating households?**
+
+The survey questions focus on three aspects:
+
+• Household profile: location, number of people, number of available
+vehicles, income category, housing status, presence of individuals with
+mobility limitations due to permanent disability;
+
+• Profile of each household member: age, gender, whether they have a
+driver's licence, whether they have a public transit pass, whether they
+subscribe to a car-sharing service, occupation, where they work/study,
+remote work/study habits;
+
+• Travel profile of each household member (i.e., information about each
+trip made on the day prior to opening the questionnaire): purpose,
+departure time, origin and destination, modes of transportation used,
+and if applicable, public transit lines used, where they changed modes
+of transportation, and workplace parking.
+
+**In the questionnaire, I need to report my travel for a specific day,
+but this day is not representative of my daily travel.**
+
+The goal of the survey is to understand the travel practices of the
+entire community during an average weekday. It is normal and
+statistically acceptable to have a subset of respondents whose travel on
+the surveyed day may be more or less representative of their usual
+travel. It is important to describe what you actually did.
+
+**I received an invitation in the mail to complete the online
+questionnaire. Can I get assistance?**
+
+Yes, assistance is available. Residents invited to participate in the
+online survey can contact us by email at
+
+**Why are you asking for so many details?**
+
+The goal is to get an accurate description of the trips made. To do
+this, knowing the locations of origin and destination is necessary. The
+more precise the location, the more detailed the analysis can be.
+Details of each individual trip is needed to understand certain
+phenomena, such as which mode of transportation is chosen for a trip.
+However, all results are presented in aggregated data form.


### PR DESCRIPTION
The FAQ goes into the footer for now until we find a better place for it.

Rephrase Consent form to remove form in footer, closes #241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated homepage introduction for the 2025 Saguenay Origin‑Destination Survey (partners, regional names, deadline moved to Dec 16, 2025).
  * Expanded footer FAQ with comprehensive 2025 OD Q&A (methodology, data collection, confidentiality, representativeness, participation, assistance).

* **Documentation**
  * Added bilingual 2025 consent forms (national and Saguenay) and a bilingual FAQ reference.
  * Updated contact and retention/consent wording to use EOD@transports.gouv.qc.ca and MTMD retention/destruction phrasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->