### PR TITLE
tripsIntro: set `sameLine` to `false` for personDidTripsConfirm

### DIFF
--- a/survey/src/survey/sections/tripsIntro/customWidgets.ts
+++ b/survey/src/survey/sections/tripsIntro/customWidgets.ts
@@ -161,6 +161,7 @@ export const personDidTripsConfirm: WidgetConfig.InputRadioType = {
     inputType: 'radio',
     datatype: 'string',
     twoColumns: false,
+    sameLine: false,
     label: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
         const tripsDate = getResponse(interview, '_assignedDay', null);


### PR DESCRIPTION
fixes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the trip confirmation question’s radio options to display on separate lines, improving readability and visual consistency with other radio groups.
  - Enhances usability on smaller screens by preventing cramped inline options.
  - No functional or behavioral changes; purely a layout adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->