### PR TITLE
Add daily run for the tests

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -12,6 +12,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    # Run daily tests to catch issues that could arise on a specific day
+    # * is a special character in YAML so you have to quote this string
+    - cron: '35 7 * * *'
 
 jobs:
   build-and-test:

--- a/.github/workflows/survey-ui-test.yml
+++ b/.github/workflows/survey-ui-test.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ main ]
   # We are not running on Pull Request, since we need the Google API Key
+  schedule:
+    # Run daily tests to catch issues that could arise on a specific day
+    # * is a special character in YAML so you have to quote this string
+    - cron: '45 7 * * *'
 
 jobs:
   build-and-test-ui:


### PR DESCRIPTION
We had tests that were failing only on sunday. Make sure we catch those problems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * CI workflows for build/test and UI test now run on a daily schedule in addition to existing event-based triggers. This change only affects automation timing and does not modify any jobs or steps. No impact to product features or behavior; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->