### PR TITLE
Add 2025 branch to the various github workflows

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - "main"
+      - "2025"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -9,9 +9,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 2025 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 2025 ]
   schedule:
     # Run daily tests to catch issues that could arise on a specific day
     # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/survey-ui-test.yml
+++ b/.github/workflows/survey-ui-test.yml
@@ -4,7 +4,7 @@ name: Survey UI Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 2025 ]
   # We are not running on Pull Request, since we need the Google API Key
   schedule:
     # Run daily tests to catch issues that could arise on a specific day

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: 
       - "main"
+      - "2025"
 
 jobs:
   pr-build-check:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI and container build workflows to include the 2025 branch for push and pull request events.
  * Enabled Docker image builds and test runs (including survey UI tests) when targeting or pushing to the 2025 branch.
  * No changes to job logic, schedules, or application behavior; this only broadens branch coverage.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->