### PR TITLE
Update Evolution by adding more gender labels and resolve a bug with the back button.

### DIFF
--- a/survey/locales/en/visitedPlaces.yaml
+++ b/survey/locales/en/visitedPlaces.yaml
@@ -21,6 +21,8 @@ onTheRoadArrivalType: Where did {{nickname}} end their work trip on the road?
 onTheRoadArrivalType_male: Where did {{nickname}} end his work trip on the road?
 onTheRoadArrivalType_female: Where did {{nickname}} end her work trip on the road?
 onTheRoadArrivalType_one: Where did you end your work trip on the road activity?
+onTheRoadArrivalType_male_one: Where did you end your work trip on the road activity?
+onTheRoadArrivalType_female_one: Where did you end your work trip on the road activity?
 alreadyVisitedBySelfOrAnotherHouseholdMember: >-
     Did you previously locate this place on the map?<br /><span class="_pale _oblique">In
     {{nickname}}'s travel diary or that of another household member.</span>
@@ -43,6 +45,12 @@ _previousPreviousDepartureTime_female: >-
     At what time did {{nickname}} leave the previous location ({{visitedPlaceDescription}})
     before going to her usual work place?
 _previousPreviousDepartureTime_one: >-
+    At what time did you leave the previous location ({{visitedPlaceDescription}})
+    before going to your usual work place?
+_previousPreviousDepartureTime_male_one: >-
+    At what time did you leave the previous location ({{visitedPlaceDescription}})
+    before going to your usual work place?
+_previousPreviousDepartureTime_female_one: >-
     At what time did you leave the previous location ({{visitedPlaceDescription}})
     before going to your usual work place?
 arrivalTime: '{{nickname}} arrived {{atPlace}} at:'
@@ -84,6 +92,10 @@ PreviousDepartureTime_home_workOnTheRoad_female: >-
     At what time did {{nickname}} leave home before starting her on the road trips?
 PreviousDepartureTime_home_workOnTheRoad_one: At what time did you leave home before
     starting your on the road trips?
+PreviousDepartureTime_home_workOnTheRoad_male_one: At what time did you leave home
+    before starting your on the road trips?
+PreviousDepartureTime_home_workOnTheRoad_female_one: At what time did you leave home
+    before starting your on the road trips?
 PreviousDepartureTime_usualWorkPlace_workOnTheRoad: >-
     At what time did {{nickname}} leave their usual work place before starting their
     on the road trips?
@@ -94,6 +106,12 @@ PreviousDepartureTime_usualWorkPlace_workOnTheRoad_female: >-
     At what time did {{nickname}} leave her usual work place before starting her on
     the road trips?
 PreviousDepartureTime_usualWorkPlace_workOnTheRoad_one: >-
+    At what time did you leave your usual work place before starting your on the road
+    trips?
+PreviousDepartureTime_usualWorkPlace_workOnTheRoad_male_one: >-
+    At what time did you leave your usual work place before starting your on the road
+    trips?
+PreviousDepartureTime_usualWorkPlace_workOnTheRoad_female_one: >-
     At what time did you leave your usual work place before starting your on the road
     trips?
 Activity: 'Specify :'
@@ -146,6 +164,10 @@ _previousPreviousDepartureTimeHomeToUsualWorkplace_female: '{{nickname}} left ho
     to go to her usual work place?'
 _previousPreviousDepartureTimeHomeToUsualWorkplace_one: You left home to go to your
     usual work place at?
+_previousPreviousDepartureTimeHomeToUsualWorkplace_male_one: You left home to go to
+    your usual work place at?
+_previousPreviousDepartureTimeHomeToUsualWorkplace_female_one: You left home to go
+    to your usual work place at?
 _previousArrivalTimeDepartureTypeHome: >-
     At what time did {{nickname}} arrive home before starting their on the road trips?
 _previousArrivalTimeDepartureTypeHome_male: >-
@@ -154,6 +176,10 @@ _previousArrivalTimeDepartureTypeHome_female: >-
     At what time did {{nickname}} arrive home before starting her on the road trips?
 _previousArrivalTimeDepartureTypeHome_one: At what time did you arrive home before
     starting your on the road trips?
+_previousArrivalTimeDepartureTypeHome_male_one: At what time did you arrive home before
+    starting your on the road trips?
+_previousArrivalTimeDepartureTypeHome_female_one: At what time did you arrive home
+    before starting your on the road trips?
 _previousArrivalTimeDepartureTypeUsualWorkPlace: >-
     At what time did {{nickname}} arrive at their usual work place before starting
     their on the road trips?
@@ -166,6 +192,12 @@ _previousArrivalTimeDepartureTypeUsualWorkPlace_female: >-
 _previousArrivalTimeDepartureTypeUsualWorkPlace_one: >-
     At what time did you arrive at your usual work place before starting your on the
     road trips?
+_previousArrivalTimeDepartureTypeUsualWorkPlace_male_one: >-
+    At what time did you arrive at your usual work place before starting your on the
+    road trips?
+_previousArrivalTimeDepartureTypeUsualWorkPlace_female_one: >-
+    At what time did you arrive at your usual work place before starting your on the
+    road trips?
 _previousArrivalTimeDepartureTypeOther: >-
     At what time did {{nickname}} arrive at the previous location ({{visitedPlaceDescription}})
     before starting their on the road trips?
@@ -176,6 +208,12 @@ _previousArrivalTimeDepartureTypeOther_female: >-
     At what time did {{nickname}} arrive at the previous location ({{visitedPlaceDescription}})
     before starting her on the road trips?
 _previousArrivalTimeDepartureTypeOther_one: >-
+    At what time did you arrive at the previous location ({{visitedPlaceDescription}})
+    before starting your on the road trips?
+_previousArrivalTimeDepartureTypeOther_male_one: >-
+    At what time did you arrive at the previous location ({{visitedPlaceDescription}})
+    before starting your on the road trips?
+_previousArrivalTimeDepartureTypeOther_female_one: >-
     At what time did you arrive at the previous location ({{visitedPlaceDescription}})
     before starting your on the road trips?
 arrivalTimeOnTheRoad: '{{nickname}} started their work trip on the road at:'
@@ -197,6 +235,10 @@ onTheRoadArrivalTypeStayedThereUntilTheNextDay_female: '{{nickname}} completed h
     work on the road trips after 4AM the next day'
 onTheRoadArrivalTypeStayedThereUntilTheNextDay_one: I completed my work on the road
     trips after 4AM the next day
+onTheRoadArrivalTypeStayedThereUntilTheNextDay_male_one: I completed my work on the
+    road trips after 4AM the next day
+onTheRoadArrivalTypeStayedThereUntilTheNextDay_female_one: I completed my work on
+    the road trips after 4AM the next day
 nextPlaceRadioChoices.stayedHomeUntilTheNextDay: Stayed home until the next day
 nextPlaceRadioChoices.stayedThereUntilTheNextDay: Stayed at this place until the next
     day

--- a/survey/locales/fr/household.yaml
+++ b/survey/locales/fr/household.yaml
@@ -133,6 +133,9 @@ travelToWorkDays_male_one: >-
 travelToWorkDays_female_one: >-
     Durant la <strong>semaine dernière</strong>, quand vous êtes-vous <strong>déplacée</strong>
     pour le <strong>travail</strong>?
+travelToWorkDays_custom_one: >-
+    Durant la <strong>semaine dernière</strong>, quand vous êtes-vous <strong>déplacé·e</strong>
+    pour le <strong>travail</strong>?
 remoteWorkDays: >-
     Durant la <strong>semaine dernière</strong>, quand {{nickname}} a-t-il/elle fait
     du <strong>télétravail</strong>?
@@ -146,6 +149,12 @@ remoteWorkDays_custom: >-
     Durant la <strong>semaine dernière</strong>, quand {{nickname}} a-t-iel fait du
     <strong>télétravail</strong>?
 remoteWorkDays_one: >-
+    Durant la <strong>semaine dernière</strong>, quand avez-vous fait du <strong>télétravail</strong>?
+remoteWorkDays_male_one: >-
+    Durant la <strong>semaine dernière</strong>, quand avez-vous fait du <strong>télétravail</strong>?
+remoteWorkDays_female_one: >-
+    Durant la <strong>semaine dernière</strong>, quand avez-vous fait du <strong>télétravail</strong>?
+remoteWorkDays_custom_one: >-
     Durant la <strong>semaine dernière</strong>, quand avez-vous fait du <strong>télétravail</strong>?
 household.save: Enregistrer et continuer
 addGroupedObject: Ajouter une personne manquante

--- a/survey/locales/fr/tripsIntro.yaml
+++ b/survey/locales/fr/tripsIntro.yaml
@@ -49,6 +49,12 @@ personDidTripsConfirm_female: >-
 personDidTripsConfirm_one: >-
     Vous avez déjà déclaré des déplacements. Confirmez-vous qu'ils sont erronés et
     que vous n'avez fait aucun déplacement le {{formattedTripsDate}}?
+personDidTripsConfirm_male_one: >-
+    Vous avez déjà déclaré des déplacements. Confirmez-vous qu'ils sont erronés et
+    que vous n'avez fait aucun déplacement le {{formattedTripsDate}}?
+personDidTripsConfirm_female_one: >-
+    Vous avez déjà déclaré des déplacements. Confirmez-vous qu'ils sont erronés et
+    que vous n'avez fait aucun déplacement le {{formattedTripsDate}}?
 didTripsIntro: >-
     Nous allons vous demander d'indiquer les lieux où {{nickname}} est allé.e le {{assignedDate}}
     (inclure les lieux visités jusqu'à 4:00 le lendemain matin)<br /><br /><span class="_green">-

--- a/survey/locales/fr/visitedPlaces.yaml
+++ b/survey/locales/fr/visitedPlaces.yaml
@@ -39,6 +39,12 @@ onTheRoadArrivalType_custom: À quel endroit {{nickname}} a-t-iel terminé ses d
     sur la route?
 onTheRoadArrivalType_one: À quel endroit avez-vous terminé vos déplacements sur la
     route?
+onTheRoadArrivalType_male_one: À quel endroit avez-vous terminé vos déplacements sur
+    la route?
+onTheRoadArrivalType_female_one: À quel endroit avez-vous terminé vos déplacements
+    sur la route?
+onTheRoadArrivalType_custom_one: À quel endroit avez-vous terminé vos déplacements
+    sur la route?
 alreadyVisitedBySelfOrAnotherHouseholdMember: >-
     Avez-vous déjà localisé ce lieu?<br /><span class="_pale _oblique">Dans l'entrevue
     de {{nickname}} ou dans celles des autres membres du ménage.</span>
@@ -64,6 +70,15 @@ _previousPreviousDepartureTime_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté le lieu précédent ({{visitedPlaceDescription}})
     avant de se rendre à son lieu habituel de travail?
 _previousPreviousDepartureTime_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{visitedPlaceDescription}})
+    avant de vous rendre à votre lieu habituel de travail?
+_previousPreviousDepartureTime_male_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{visitedPlaceDescription}})
+    avant de vous rendre à votre lieu habituel de travail?
+_previousPreviousDepartureTime_female_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{visitedPlaceDescription}})
+    avant de vous rendre à votre lieu habituel de travail?
+_previousPreviousDepartureTime_custom_one: >-
     À quelle heure avez-vous quitté le lieu précédent ({{visitedPlaceDescription}})
     avant de vous rendre à votre lieu habituel de travail?
 arrivalTime: '{{nickname}} est arrivé.e {{atPlace}} à:'
@@ -104,6 +119,10 @@ nextPlaceCategory_female_one: >-
     Après avoir été {{atPlace}}, vous êtes…<br /><span class="_pale _oblique">Si vous
     avez quitté le lieu après 4h du matin le lendemain, merci de considérer pour l'enquête
     que vous y êtes restée jusqu'au lendemain et de sélectionner la réponse adaptée.</span>
+nextPlaceCategory_custom_one: >-
+    Après avoir été {{atPlace}}, vous êtes…<br /><span class="_pale _oblique">Si vous
+    avez quitté le lieu après 4h du matin le lendemain, merci de considérer pour l'enquête
+    que vous y êtes resté.e jusqu'au lendemain et de sélectionner la réponse adaptée.</span>
 departureTime: '{{nickname}} a quitté {{place}} à:'
 departureTime_one: 'Vous avez quitté {{place}} à:'
 visitedPlacesSave: Confirmer
@@ -118,6 +137,12 @@ PreviousDepartureTime_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté le lieu précédent ({{previousVisitedPlaceDescription}})?
 PreviousDepartureTime_one: >-
     À quelle heure avez-vous quitté le lieu précédent ({{previousVisitedPlaceDescription}})?
+PreviousDepartureTime_male_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{previousVisitedPlaceDescription}})?
+PreviousDepartureTime_female_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{previousVisitedPlaceDescription}})?
+PreviousDepartureTime_custom_one: >-
+    À quelle heure avez-vous quitté le lieu précédent ({{previousVisitedPlaceDescription}})?
 PreviousDepartureTime_home_workUsual: >-
     À quelle heure {{nickname}} a-t-il/elle quitté le domicile pour aller au travail?
 PreviousDepartureTime_home_workUsual_male: À quelle heure {{nickname}} a-t-il quitté
@@ -128,6 +153,12 @@ PreviousDepartureTime_home_workUsual_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté le domicile pour aller au travail?
 PreviousDepartureTime_home_workUsual_one: À quelle heure avez-vous quitté le domicile
     pour aller au travail?
+PreviousDepartureTime_home_workUsual_male_one: À quelle heure avez-vous quitté le
+    domicile pour aller au travail?
+PreviousDepartureTime_home_workUsual_female_one: À quelle heure avez-vous quitté le
+    domicile pour aller au travail?
+PreviousDepartureTime_home_workUsual_custom_one: À quelle heure avez-vous quitté le
+    domicile pour aller au travail?
 PreviousDepartureTime_home_schoolUsual: >-
     À quelle heure {{nickname}} a-t-il/elle quitté le domicile pour aller au lieu
     d'études/école?
@@ -138,6 +169,12 @@ PreviousDepartureTime_home_schoolUsual_female: >-
 PreviousDepartureTime_home_schoolUsual_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté le domicile pour aller au lieu d'études/école?
 PreviousDepartureTime_home_schoolUsual_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller au lieu d'études/école?
+PreviousDepartureTime_home_schoolUsual_male_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller au lieu d'études/école?
+PreviousDepartureTime_home_schoolUsual_female_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller au lieu d'études/école?
+PreviousDepartureTime_home_schoolUsual_custom_one: >-
     À quelle heure avez-vous quitté le domicile pour aller au lieu d'études/école?
 PreviousDepartureTime_home_other: >-
     À quelle heure {{nickname}} a-t-il/elle quitté le domicile pour aller à cet endroit
@@ -152,6 +189,12 @@ PreviousDepartureTime_home_other_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté le domicile pour aller à cet endroit
     ({{visitedPlaceDescription}})?
 PreviousDepartureTime_home_other_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller à cet endroit ({{visitedPlaceDescription}})?
+PreviousDepartureTime_home_other_male_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller à cet endroit ({{visitedPlaceDescription}})?
+PreviousDepartureTime_home_other_female_one: >-
+    À quelle heure avez-vous quitté le domicile pour aller à cet endroit ({{visitedPlaceDescription}})?
+PreviousDepartureTime_home_other_custom_one: >-
     À quelle heure avez-vous quitté le domicile pour aller à cet endroit ({{visitedPlaceDescription}})?
 PreviousDepartureTime_home_workOnTheRoad: >-
     À quelle heure {{nickname}} a-t-il/elle quitté le domicile avant de débuter ses
@@ -168,6 +211,15 @@ PreviousDepartureTime_home_workOnTheRoad_custom: >-
 PreviousDepartureTime_home_workOnTheRoad_one: >-
     À quelle heure avez-vous quitté le domicile avant de débuter vos déplacements
     sur la route?
+PreviousDepartureTime_home_workOnTheRoad_male_one: >-
+    À quelle heure avez-vous quitté le domicile avant de débuter vos déplacements
+    sur la route?
+PreviousDepartureTime_home_workOnTheRoad_female_one: >-
+    À quelle heure avez-vous quitté le domicile avant de débuter vos déplacements
+    sur la route?
+PreviousDepartureTime_home_workOnTheRoad_custom_one: >-
+    À quelle heure avez-vous quitté le domicile avant de débuter vos déplacements
+    sur la route?
 PreviousDepartureTime_usualWorkPlace_workOnTheRoad: >-
     À quelle heure {{nickname}} a-t-il/elle quitté son lieu de travail habituel avant
     de débuter ses déplacements sur la route?
@@ -181,6 +233,15 @@ PreviousDepartureTime_usualWorkPlace_workOnTheRoad_custom: >-
     À quelle heure {{nickname}} a-t-iel quitté son lieu de travail habituel avant
     de débuter ses déplacements sur la route?
 PreviousDepartureTime_usualWorkPlace_workOnTheRoad_one: >-
+    À quelle heure avez-vous quitté votre lieu de travail habituel avant de débuter
+    vos déplacements sur la route?
+PreviousDepartureTime_usualWorkPlace_workOnTheRoad_male_one: >-
+    À quelle heure avez-vous quitté votre lieu de travail habituel avant de débuter
+    vos déplacements sur la route?
+PreviousDepartureTime_usualWorkPlace_workOnTheRoad_female_one: >-
+    À quelle heure avez-vous quitté votre lieu de travail habituel avant de débuter
+    vos déplacements sur la route?
+PreviousDepartureTime_usualWorkPlace_workOnTheRoad_custom_one: >-
     À quelle heure avez-vous quitté votre lieu de travail habituel avant de débuter
     vos déplacements sur la route?
 Activity: 'Spécifier :'
@@ -254,6 +315,9 @@ _previousArrivalTimeDepartureTypeHome_male_one: >-
 _previousArrivalTimeDepartureTypeHome_female_one: >-
     À quelle heure êtes-vous arrivée au domicile avant de débuter vos déplacements
     sur la route?
+_previousArrivalTimeDepartureTypeHome_custom_one: >-
+    À quelle heure êtes-vous arrivé.e au domicile avant de débuter vos déplacements
+    sur la route?
 _previousArrivalTimeDepartureTypeUsualWorkPlace: >-
     À quelle heure {{nickname}} est-il/elle arrivé.e à son lieu de travail habituel
     avant de débuter ses déplacements sur la route?
@@ -275,6 +339,9 @@ _previousArrivalTimeDepartureTypeUsualWorkPlace_male_one: >-
 _previousArrivalTimeDepartureTypeUsualWorkPlace_female_one: >-
     À quelle heure êtes-vous arrivée à votre lieu de travail habituel avant de débuter
     vos déplacements sur la route?
+_previousArrivalTimeDepartureTypeUsualWorkPlace_custom_one: >-
+    À quelle heure êtes-vous arrivé.e à votre lieu de travail habituel avant de débuter
+    vos déplacements sur la route?
 _previousArrivalTimeDepartureTypeOther: >-
     À quelle heure {{nickname}} est-il/elle arrivé.e au lieu précédent ({{visitedPlaceDescription}})
     avant de débuter ses déplacements sur la route?
@@ -295,6 +362,9 @@ _previousArrivalTimeDepartureTypeOther_male_one: >-
     avant de débuter vos déplacements sur la route?
 _previousArrivalTimeDepartureTypeOther_female_one: >-
     À quelle heure êtes-vous arrivée au lieu précédent ({{visitedPlaceDescription}})
+    avant de débuter vos déplacements sur la route?
+_previousArrivalTimeDepartureTypeOther_custom_one: >-
+    À quelle heure êtes-vous arrivé.e au lieu précédent ({{visitedPlaceDescription}})
     avant de débuter vos déplacements sur la route?
 arrivalTimeOnTheRoad: '{{nickname}} a commencé ses déplacements sur la route à: '
 arrivalTimeOnTheRoad_one: 'Vous avez commencé vos déplacements sur la route à:'


### PR DESCRIPTION
# Pull request

## Description
Update Evolution by adding more gender labels and resolve a bug with the back button.
Fix: #228, fix: #179
The back button doesn't reload forever, anymore, but it stay in the same page forever. The gender label doesn't bug anymore when there is a count and gender context. Do 'yarn generateSurvey'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded English and French survey prompts with gender-specific and custom “one” variants across visited places, trips introduction, and household questions.
  - Added additional “one” forms for specific prompts (e.g., on-the-road arrival, stroll), improving clarity and inclusivity without changing existing texts.
- Chores
  - Updated submodule to the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->