### PR TITLE
fix missing poly consent in intro for saguenay

### DIFF
--- a/survey/locales/en/survey.yaml
+++ b/survey/locales/en/survey.yaml
@@ -50,7 +50,10 @@ homepage:
         participate.</li></ul><br/><p class="left">For more information about the Survey, please visit the following link : <a
         href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
         target="_blank">Enquêtes origine-destination - Transports et Mobilité
-        durable Québec (gouv.qc.ca)</a>.</p></details>
+        durable Québec (gouv.qc.ca)</a>.</p><p class="left">You must also consent to this
+        form from Polytechnique Montreal: <a
+        href="/dist/documents/od_nationale_saguenay_2025_consent_poly_en.pdf"
+        target="_blank">Consent Information</a></p></details>
     introduction: >-
         <p class="left">The <span class="_strong">Origin-Destination
         Survey</span> is underway and your participation is important for its
@@ -92,7 +95,10 @@ homepage:
         information will be retained for a period determined by MTMD's retention
         schedule.</li><li>If you refuse to provide the required personal
         information for the Survey, you will not be able to
-        participate.</li></ul><br/><p class="left">You must also consent to this
+        participate.</li></ul><br/><p class="left">For more information about the Survey, please visit the following link : <a
+        href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
+        target="_blank">Enquêtes origine-destination - Transports et Mobilité
+        durable Québec (gouv.qc.ca)</a>.</p><p class="left">You must also consent to this
         form from Polytechnique Montreal: <a
         href="/dist/documents/od_nationale_saguenay_2025_consent_poly_en.pdf"
         target="_blank">Consent Information</a></p></details>

--- a/survey/locales/fr/survey.yaml
+++ b/survey/locales/fr/survey.yaml
@@ -59,7 +59,10 @@ homepage:
         suivante: <a
         href="https://www.transports.gouv.qc.ca/fr/ministere/Planification-transports/enquetes-origine-destination/Pages/enquetes-origine-destination.aspx"
         target="_blank">Enquêtes origine-destination - Transports et Mobilité
-        durable Québec (gouv.qc.ca)</a>.</p></details>
+        durable Québec (gouv.qc.ca)</a>.</p><p class="left">Vous devez également
+        consentir à ce formulaire de Polytechnique Montréal: <a
+        href="/dist/documents/od_nationale_saguenay_2025_consent_poly_fr.pdf"
+        target="_blank">Information de consentement</a></p></details>
     introduction: >-
         <p class="left"><span class="_strong">L'enquête
         Origine-Destination</span> est en cours et votre participation est


### PR DESCRIPTION
closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Consent Information” link to the English survey content, providing direct access to the consent PDF.
  * Enhanced the French (Saguenay) introduction with an “Information de consentement” link to the consent PDF.
  * Included an additional reference link to the official Enquêtes origine-destination page within consent sections.
  * Clarified consent-related text in both languages for improved transparency.
  * No changes to functionality or behavior; updates are content-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->