### PR TITLE
visitedPlaces: update condition and button visibility for geography

### DIFF
--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -1039,26 +1039,35 @@ export const visitedPlaceGeography: WidgetConfig.InputMapFindPlaceType = {
         ];
         return validations;
     },
+    showSearchPlaceButton: (interview, path) => {
+        // Do not show if the place is a shortcut
+        const visitedPlace: any = getResponse(interview, path, null, '../');
+        return _isBlank(visitedPlace.shortcut);
+    },
     conditional: function (interview, path) {
-        const activity: any = getResponse(interview, path, null, '../activity');
+        const visitedPlace: any = getResponse(interview, path, null, '../');
+        const activity = visitedPlace.activity;
         const person = odSurveyHelpers.getActivePerson({ interview });
-        if (
-            activity &&
-            activity === 'workUsual' &&
-            (person as any).usualWorkPlace &&
-            (person as any).usualWorkPlace.geography
-        ) {
+        if (activity === 'workUsual' && (person as any).usualWorkPlace && (person as any).usualWorkPlace.geography) {
             return [false, (person as any).usualWorkPlace.geography];
-        } else if (
-            activity &&
+        }
+        if (
             activity === 'schoolUsual' &&
             (person as any).usualSchoolPlace &&
             (person as any).usualSchoolPlace.geography
         ) {
             return [false, (person as any).usualSchoolPlace.geography];
         }
+        const visitedPlaceAlreadyVisited = getResponse(
+            interview,
+            path,
+            null,
+            '../alreadyVisitedBySelfOrAnotherHouseholdMember'
+        );
         return [
-            !_isBlank(activity) && ![...loopActivities, 'home'].includes(activity) && ![''].includes(activity),
+            !_isBlank(activity) &&
+                ![...loopActivities, 'home'].includes(activity) &&
+                !(visitedPlaceAlreadyVisited === 'yes' && _isBlank(visitedPlace.shortcut)),
             null
         ];
     }


### PR DESCRIPTION
fixes #234

Use a conditional similar to the one of the `visitedPlaceName` widget to display the map, ie, hide if the alreadyVisitedPlace is `yes`. But unlike the name, the map is shown when a shortcut is selected, but without the search button.

If the location is changed manually by the user, it cancels the shortcut and the name is visible again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The place search button now appears only when appropriate, based on whether the place is a shortcut and prior visit status.
  * Geography search visibility adapts to the full visited place context for more accurate prompts.

* **Bug Fixes**
  * Prevents showing the search button for shortcut entries, reducing confusion.
  * Avoids duplicate or conflicting entries by checking if the place was already visited by the user or household members.
  * Tightens final validation to reflect visit history and shortcut status for more reliable survey completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->