### PR TITLE
home: update date to display in hh size popup

### DIFF
--- a/survey/locales/en/customLabel.yaml
+++ b/survey/locales/en/customLabel.yaml
@@ -5,7 +5,7 @@ GeographyAfterRefresh: >-
 HomeHouseholdSizeHelpContent: >-
     <ul><li><strong>Include:</strong></li><ul><li>Yourself</li><li>Children in
     joint custody if they were present at your home on
-    {{assignedDate}}</li><li>Roomers and roommates, as well as all those living
+    <strong>{{assignedDate}}</strong></li><li>Roomers and roommates, as well as all those living
     in a domestic community</li></ul></ul>
 HybridElectricExceedsTotal: >-
     The total number of hybrid and electric vehicles cannot exceed the total

--- a/survey/locales/fr/customLabel.yaml
+++ b/survey/locales/fr/customLabel.yaml
@@ -5,7 +5,7 @@ GeographyAfterRefresh: >-
 HomeHouseholdSizeHelpContent: >-
     <ul><li><strong>Inclure:</strong></li><ul><li>Vous-même</li><li>Les enfants
     en garde partagée s'ils étaient présents à votre domicile le
-    {{assignedDate}}</li><li>Les chambreuses, chambreurs et colocataires, ainsi
+    <strong>{{assignedDate}}</strong></li><li>Les chambreuses, chambreurs et colocataires, ainsi
     que tous ceux et celles qui vivent en  communauté domestique</li></ul></ul>
 HybridElectricExceedsTotal: >-
     Le nombre total de véhicules hybrides et électriques ne peut pas dépasser le

--- a/survey/src/survey/common/customHelpPopup.tsx
+++ b/survey/src/survey/common/customHelpPopup.tsx
@@ -5,6 +5,7 @@ import { getResponse } from 'evolution-common/lib/utils/helpers';
 import i18n from 'chaire-lib-frontend/lib/config/i18n.config';
 import * as odSurveyHelpers from 'evolution-common/lib/services/odSurvey/helpers';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { getFormattedDate } from 'evolution-frontend/lib/services/display/frontendHelper';
 // import { countPersons, getPersonsObject, selfResponseAge } from '../helperFunctions/helper';
 
 export const cityHelpPopup: HelpPopup = {
@@ -30,15 +31,15 @@ export const householdSizeHelpPopup: HelpPopup = {
         en: 'Who to include?'
     },
     containsHtml: true,
-    content: (t: TFunction, interview) =>
+    content: (t: TFunction, interview) => {
         // assigned date should be the day before the interview started:
-        t('customLabel:HomeHouseholdSizeHelpContent', {
-            assignedDate: moment
-                .unix(getResponse(interview, '_startedAt') as number)
-                .subtract(1, 'days')
-                .locale(i18n.language)
-                .format('LL')
-        })
+        const assignedDay = getResponse(interview, '_assignedDay') as string;
+        const assignedDate = getFormattedDate(assignedDay, { withDayOfWeek: true, withRelative: true });
+
+        return t('customLabel:HomeHouseholdSizeHelpContent', {
+            assignedDate
+        });
+    }
 };
 
 export const householdCarNumberHelpPopup: HelpPopup = {


### PR DESCRIPTION
fixes #297

Display the `_assignedDay` date with day of week and relative, and put in bold to highlight the date in the text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Household Size help popup now shows the assigned date in a clearer, human-friendly format (including day of week and relative phrasing) for improved readability.
  - The assigned date is now bolded to draw attention within the help content.

- **Localization**
  - Updated English and French help content to reflect the new date formatting and emphasis, ensuring consistent presentation across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->