### PR TITLE
tripsIntro: show relative days in personDidTrips label

### DIFF
--- a/survey/src/survey/sections/tripsIntro/customWidgets.ts
+++ b/survey/src/survey/sections/tripsIntro/customWidgets.ts
@@ -107,8 +107,8 @@ export const personDidTrips: WidgetConfig.InputRadioType = {
     label: (t: TFunction, interview) => {
         const activePerson = odSurveyHelper.getActivePerson({ interview });
         const nickname = activePerson?.nickname || t('survey:noNickname');
-        const assignedDay = getResponse(interview, '_assignedDay');
-        const assignedDate = moment(assignedDay).locale(i18n.language).format('dddd LL');
+        const assignedDay = getResponse(interview, '_assignedDay') as string;
+        const assignedDate = getFormattedDate(assignedDay, { withDayOfWeek: true, withRelative: true });
         return t('tripsIntro:personDidTrips', {
             context: activePerson?.gender || activePerson?.sexAssignedAtBirth,
             nickname,


### PR DESCRIPTION
fixes #202

Use the `getFormattedDate, with relative set to `true` to display relative time in parenthesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced date display in the trips introduction: dates now include the day of the week and a relative context (e.g., “today,” “tomorrow”) for clearer, more intuitive reading.
  - Improved localization of date formatting to better match user language settings.
  - Provides a more user-friendly label when indicating when a person took trips, making timelines easier to understand at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->