### PR TITLE
Fix yarn format command in macos

### DIFF
--- a/survey/package.json
+++ b/survey/package.json
@@ -25,7 +25,7 @@
     "start:admin:tracing": "yarn node -r ../tracing.js lib/admin/serverAdmin.js --max-old-space-size=4096",
     "start:debug": "cross-env DEBUG=express:* yarn node --trace-warnings lib/server.js --max-old-space-size=4096",
     "test": "cross-env NODE_ENV=test jest --config=jest.config.js",
-    "format": "prettier-eslint ./**/*.{ts,tsx} --write",
+    "format": "prettier-eslint \"./**/*.{ts,tsx}\" --write",
     "lint": "eslint .",
     "unimported": "npx unimported",
     "test:ui": "LOCALE_DIR=$(pwd)/locales TRANSITION_DOTENV='../.env' npx playwright test",


### PR DESCRIPTION
In macos, when there is no quotes around the prettier path, it ignores most files and will not fix formatting in several subdirectories. Using quotes seems to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted developer tooling configuration for more reliable project-wide formatting.
  * Updated an internal submodule reference to a newer revision.
  * No user-facing changes: UI, features, and performance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->