### PR TITLE
Increase the default min zoom for map inputs

### DIFF
--- a/survey/src/survey/common/customValidations.ts
+++ b/survey/src/survey/common/customValidations.ts
@@ -77,7 +77,7 @@ export const getGeographyCustomValidation = ({ value, interview, path }) => {
                 geography.properties.lastAction &&
                 (geography.properties.lastAction === 'mapClicked' ||
                     geography.properties.lastAction === 'markerDragged') &&
-                geography.properties.zoom < 14,
+                geography.properties.zoom < 15,
             errorMessage: {
                 fr: 'Le positionnement du lieu n\'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l\'icône.',
                 en: 'The positioning of the place is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'

--- a/survey/src/survey/sections/household/customWidgets.tsx
+++ b/survey/src/survey/sections/household/customWidgets.tsx
@@ -133,7 +133,7 @@ export const personUsualWorkPlaceGeography: InputMapFindPlaceType = {
                     geography.properties.lastAction &&
                     (geography.properties.lastAction === 'mapClicked' ||
                         geography.properties.lastAction === 'markerDragged') &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: {
                     fr: 'Le positionnement du lieu n\'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l\'icône.',
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
@@ -209,7 +209,7 @@ export const personUsualSchoolPlaceGeography: InputMapFindPlaceType = {
                     geography.properties.lastAction &&
                     (geography.properties.lastAction === 'mapClicked' ||
                         geography.properties.lastAction === 'markerDragged') &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: {
                     fr: 'Le positionnement du lieu n\'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l\'icône.',
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'

--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -1011,7 +1011,7 @@ export const visitedPlaceGeography: WidgetConfig.InputMapFindPlaceType = {
                     geography.properties.lastAction &&
                     (geography.properties.lastAction === 'mapClicked' ||
                         geography.properties.lastAction === 'markerDragged') &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: (t: TFunction) => t('survey:visitedPlace:locationIsNotPreciseError')
             },
             ...inaccessibleZoneGeographyCustomValidation(geography, undefined, interview, path),


### PR DESCRIPTION
According to research we did with POIs, we need to increase the default min zoom for map inputs to 15 which will be significant better than 14 which was the default.

See https://github.com/chairemobilite/evolution/issues/849