### PR TITLE
Add missing places icons in home widget

### DIFF
--- a/survey/src/survey/sections/home/customWidgets.tsx
+++ b/survey/src/survey/sections/home/customWidgets.tsx
@@ -17,6 +17,14 @@ export const home_geography: inputTypes.InputMapFindPlaceType = {
         url: getActivityMarkerIcon('home'),
         size: [70, 70]
     },
+    placesIcon: {
+        url: (interview, path) => '/dist/icons/interface/markers/marker_round_with_small_circle.svg',
+        size: [35, 35]
+    },
+    selectedIcon: {
+        url: (interview, path) => '/dist/icons/interface/markers/marker_round_with_small_circle_selected.svg',
+        size: [35, 35]
+    },
     geocodingQueryString: (interview) => {
         // TODO: Add country and region to the geocoding query string
         const city = surveyHelperNew.getResponse(interview, 'home.city', null);


### PR DESCRIPTION
closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added distinct map markers for “places” and “selected” states in the home location selection, making it easier to differentiate results and your current choice.

- Style
  - Introduced smaller 35×35 markers for supplementary states while keeping the primary home marker size unchanged, improving visual clarity in dense areas and on touch devices.
  - Enhanced selection feedback with a dedicated “selected” icon for clearer, immediate visual confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->