### PR TITLE
Remove unused env variable in webpack export

### DIFF
--- a/survey/webpack.admin.config.js
+++ b/survey/webpack.admin.config.js
@@ -145,19 +145,9 @@ module.exports = (env) => {
         'process.env': {
           'IS_BROWSER'                  : JSON.stringify(true),
           'HOST'                        : JSON.stringify(process.env.HOST),
-          'TRROUTING_HOST'              : JSON.stringify(process.env.TRROUTING_HOST),
           'APP_NAME'                    : JSON.stringify(appIncludeName),
-          'PROJECT_SHORTNAME'           : JSON.stringify(config.projectShortname),
-          'PROJECT_SOURCE'              : JSON.stringify(process.env.PROJECT_SOURCE),
           'IS_TESTING'                  : JSON.stringify(env === 'test'),
           'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY),
-          'MAPBOX_ACCESS_TOKEN'         : JSON.stringify(process.env.MAPBOX_ACCESS_TOKEN),
-          'MAPBOX_USER_ID'              : JSON.stringify(process.env.MAPBOX_USER_ID || config.mapboxUserId),
-          'MAPBOX_STYLE_ID'             : JSON.stringify(process.env.MAPBOX_STYLE_ID || config.mapboxStyleId),
-          'PROJECT_SAMPLE'              : JSON.stringify(process.env.PROJECT_SAMPLE),
-          'MAILCHIMP_API_KEY'           : JSON.stringify(process.env.MAILCHIMP_API_KEY),
-          'MAILCHIMP_LIST_ID'           : JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-          'PHOTON_OSM_SEARCH_API_URL'   : JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL),
           EV_VARIANT: JSON.stringify(process.env.EV_VARIANT)
         },
         '__CONFIG__': JSON.stringify({

--- a/survey/webpack.config.js
+++ b/survey/webpack.config.js
@@ -147,19 +147,9 @@ module.exports = (env) => {
                 'process.env': {
                     IS_BROWSER: JSON.stringify(true),
                     HOST: JSON.stringify(process.env.HOST),
-                    TRROUTING_HOST: JSON.stringify(process.env.TRROUTING_HOST),
                     APP_NAME: JSON.stringify(appIncludeName),
-                    PROJECT_SHORTNAME: JSON.stringify(config.projectShortname),
-                    PROJECT_SOURCE: JSON.stringify(process.env.PROJECT_SOURCE),
                     IS_TESTING: JSON.stringify(env === 'test'),
                     GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY),
-                    MAPBOX_ACCESS_TOKEN: JSON.stringify(process.env.MAPBOX_ACCESS_TOKEN),
-                    MAPBOX_USER_ID: JSON.stringify(process.env.MAPBOX_USER_ID || config.mapboxUserId),
-                    MAPBOX_STYLE_ID: JSON.stringify(process.env.MAPBOX_STYLE_ID || config.mapboxStyleId),
-                    PROJECT_SAMPLE: JSON.stringify(process.env.PROJECT_SAMPLE),
-                    MAILCHIMP_API_KEY: JSON.stringify(process.env.MAILCHIMP_API_KEY),
-                    MAILCHIMP_LIST_ID: JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-                    PHOTON_OSM_SEARCH_API_URL: JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL),
                     EV_VARIANT: JSON.stringify(process.env.EV_VARIANT)
                 },
                 __CONFIG__: JSON.stringify({


### PR DESCRIPTION
Those variables are not refered anywhere in evolution, we can safely remove them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the set of environment variables exposed to the client across admin and survey builds, removing mapping, routing, newsletter, and search service keys/IDs.
  * Streamlined environment configuration to minimize sensitive data surface area.
* **Refactor**
  * Simplified client-side environment variable definitions for a leaner build.
* **Impact**
  * No user-facing changes expected; general security posture improved by limiting client-exposed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->