### PR TITLE
Fix max height in trip/activity descriptions

### DIFF
--- a/survey/src/styles/common-styles.scss
+++ b/survey/src/styles/common-styles.scss
@@ -119,16 +119,8 @@ $desktop-breakpoint: 50rem;
         align-items: center;
     }
 
-    .survey-trip-item-origin-description {
+    .survey-trip-item-origin-description, .survey-trip-item-destination-description {
         width: 45%;
-        overflow: hidden;
-        max-height: 8rem;
-    }
-
-    .survey-trip-item-destination-description {
-        width: 45%;
-        overflow: hidden;
-        max-height: 8rem;
     }
 
     &.survey-visited-place-item-selected {


### PR DESCRIPTION
Remove max height in trip/activity description. It was truncating because there was an overflow: hidden also.

closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Unified styling for trip origin and destination descriptions.
  - Removed fixed height and overflow clipping, so longer text is no longer cut off.
  - Descriptions now display full content for improved readability and accessibility.
  - Maintains existing layout width to preserve page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->