### PR TITLE
Hide schoolUsual and workUsual for non workers/students

### DIFF
--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -311,9 +311,8 @@ const visitedPlaceActivityChoices = [
                 return true;
             }
             return (
-                ['fullTimeWorker', 'partTimeWorker', 'fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(
-                    occupation
-                ) &&
+                (person as any).usualWorkPlace &&
+                ['fullTimeWorker', 'partTimeWorker', 'workerAndStudent'].includes(occupation) &&
                 activityCategory === 'work' &&
                 (!previousVisitedPlace || (previousVisitedPlace && previousVisitedPlace.activity !== 'workUsual')) &&
                 (!nextVisitedPlace || (nextVisitedPlace && nextVisitedPlace.activity !== 'workUsual'))
@@ -365,14 +364,9 @@ const visitedPlaceActivityChoices = [
             }
 
             return (
+                (person as any).usualSchoolPlace &&
                 activityCategory === 'school' &&
-                ([
-                    'fullTimeWorker',
-                    'partTimeWorker',
-                    'fullTimeStudent',
-                    'partTimeStudent',
-                    'workerAndStudent'
-                ].includes(occupation) ||
+                (['fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(occupation) ||
                     (person.age && person.age <= 15)) &&
                 (!previousVisitedPlace || (previousVisitedPlace && previousVisitedPlace.activity !== 'schoolUsual')) &&
                 (!nextVisitedPlace || (nextVisitedPlace && nextVisitedPlace.activity !== 'schoolUsual'))


### PR DESCRIPTION
closes #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Activity choices now strictly match saved locations and profile fields.
  - “Usual work” appears only if a usual workplace is set and the user is a worker (full/part-time or worker‑student).
  - “Usual school” appears only if a usual school is set and the user is a student (full/part-time or worker‑student); includes an age cap (≤15) and preserves kindergarten/childcare exceptions.
  - Removes irrelevant options for users who don’t meet these tightened conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->