### PR TITLE
Conditional: Fix shouldDisplayOnDemandTypeCustomConditional conditional

### DIFF
--- a/survey/src/survey/common/customConditionals.ts
+++ b/survey/src/survey/common/customConditionals.ts
@@ -162,19 +162,19 @@ export const isSelfDeclaredCarDriverCustomConditional: WidgetConditional = (inte
     ];
 };
 
-// Show if mode is transitTaxi or transitBus, EV_VARIANT is not 'nationale', and busLines include 'dontKnow' or 'other'
+// Show if mode is transitTaxi, or if mode is transitBus (and not nationale variant) and busLines include 'dontKnow' or 'other'.
 export const shouldDisplayOnDemandTypeCustomConditional: WidgetConditional = (interview, path) => {
     const mode = surveyHelper.getResponse(interview, path, null, '../mode');
     const busLines = surveyHelper.getResponse(interview, path, [], '../busLines') as any[];
     const isNotNationale = process.env.EV_VARIANT !== 'nationale'; // Check if EV_VARIANT is not 'nationale'
 
-    // Show if mode is transitTaxi or transitBus, EV_VARIANT is not 'nationale', and busLines include 'dontKnow' or 'other'
+    // Show if mode is transitTaxi, or if mode is transitBus (and not nationale variant) and busLines include 'dontKnow' or 'other'.
     const shouldDisplay =
-        isNotNationale &&
-        (mode === 'transitTaxi' ||
-            (mode === 'transitBus' &&
-                busLines.length > 0 &&
-                (busLines.includes('dontKnow') || busLines.includes('other'))));
+        mode === 'transitTaxi' ||
+        (isNotNationale &&
+            mode === 'transitBus' &&
+            busLines.length > 0 &&
+            (busLines.includes('dontKnow') || busLines.includes('other')));
 
     return [shouldDisplay, null];
 };


### PR DESCRIPTION
# Pull request

- [x] Pass the UI tests and manually tests.

## Description
Conditional: shouldDisplayOnDemandTypeCustomConditional conditional should also work for nationale variant survey.
Fix: #389 
Note: shouldDisplayOnDemandTypeCustomConditional should Show if mode is transitTaxi,
or if mode is transitBus (and not nationale variant) and busLines include 'dontKnow' or 'other'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The survey now consistently shows the “On-demand type” field when selecting transit taxi, and for transit bus when bus lines are marked as “don’t know” or “other.”
  - Removes unintended environment-based restrictions so users across all deployments see this field when applicable, improving relevance and reducing confusion during response entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->