### PR TITLE
visitedPlaces: fix activities condition to avoid 2 incompatbile activities in a row

### DIFF
--- a/survey/src/survey/sections/visitedPlaces/customWidgets.ts
+++ b/survey/src/survey/sections/visitedPlaces/customWidgets.ts
@@ -319,18 +319,11 @@ const visitedPlaceActivityChoices = [
             const occupation = person.occupation;
             const activityCategory = getResponse(interview, path, null, '../activityCategory');
 
-            // FIXME Taken from od_nationale_2024, but seems like this condition and the next should be merged somehow, no?
-            if (
-                activityCategory === 'work' &&
-                (person as any).usualWorkPlace &&
-                (person as any).usualWorkPlace.geography
-            ) {
-                return true;
-            }
             return (
-                (person as any).usualWorkPlace &&
-                ['fullTimeWorker', 'partTimeWorker', 'workerAndStudent'].includes(occupation) &&
                 activityCategory === 'work' &&
+                (person as any).usualWorkPlace &&
+                (person as any).usualWorkPlace.geography &&
+                ['fullTimeWorker', 'partTimeWorker', 'workerAndStudent'].includes(occupation) &&
                 validatePreviousNextPlaceIsNotActivities({ interview, incompatibleActivities: ['workUsual'] })
             );
         }


### PR DESCRIPTION
See individual commits for details

* Prevent 2 loop activities from being selected one after the other
* Fix condition for `workUsual` to avoid 2 workUsual in a row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent selecting incompatible activities in adjacent visited places (e.g., usual work/school, on-the-road work, leisure stroll), reducing erroneous or conflicting options.

* **Refactor**
  * Centralized adjacent-place checks into a reusable helper for consistent logic across activity choices. No changes to public behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->