### PR TITLE
Fix regex in transit summary in serverFieldUpdate

### DIFF
--- a/survey/src/survey/server/serverFieldUpdate.ts
+++ b/survey/src/survey/server/serverFieldUpdate.ts
@@ -335,7 +335,9 @@ export default [
         }
     },
     {
-        field: { regex: 'household.persons.*.journeys.*.trips.*.segments.*.modePre' },
+        field: {
+            regex: '^household\\.persons\\.[a-zA-Z0-9_-]+\\.journeys\\.[a-zA-Z0-9_-]+\\.trips\\.[a-zA-Z0-9_-]+\\.segments\\.[a-zA-Z0-9_-]+\\.modePre$'
+        },
         runOnValidatedData: true,
         callback: async (interview, value, path, registerUpdateOperation) => {
             const resultPath = getPath(path, '../trRoutingResult');


### PR DESCRIPTION
The regex was not escaping the "." properly and was matching way larger than it should.

This add several test to validate the matches and the non-matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tightened validation for transit summary updates so only correctly structured transit path entries are accepted.

- Tests
  - Added extensive tests covering many valid and invalid transit path patterns to prevent malformed updates.
  - Removed a duplicated test suite to avoid redundant execution.

- Chores
  - Minor formatting and end-of-file cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->