### PR TITLE
admin: add graph to display interviews by attribute

### DIFF
--- a/survey/locales/en/surveyAdmin.yaml
+++ b/survey/locales/en/surveyAdmin.yaml
@@ -3,3 +3,7 @@ downloadTrackingData: Download tracking data (CSV)
 actionSuccess: "Action successful"
 actionError: "Action failed"  
 interview_monitoring_cache_updated_successfully: "Interview monitoring cache updated successfully"
+StartedAndCompletedInterviewsPer: "Started and completed interviews by {{attribute}}"
+CSV: "Download CSV"
+strateCategories:
+  null: "Not specified"

--- a/survey/locales/fr/surveyAdmin.yaml
+++ b/survey/locales/fr/surveyAdmin.yaml
@@ -3,3 +3,7 @@ downloadTrackingData: Télécharger les données de suivi (CSV)
 actionSuccess: "Action réussie"
 actionError: "Erreur lors de l'action"
 interview_monitoring_cache_updated_successfully: "Cache de suivi mis à jour avec succès"
+StartedAndCompletedInterviewsPer: "Entrevues débutées et complétées par {{attribute}}"
+CSV: "Télécharger en CSV"
+strateCategories:
+  null: "Non spécifié"

--- a/survey/package.json
+++ b/survey/package.json
@@ -53,7 +53,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^12.3.1",
-    "react-router": "^7.5.2"
+    "react-router": "^7.5.2",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@alienfast/i18next-loader": "^2.0.2",

--- a/survey/src/admin/components/Monitoring.tsx
+++ b/survey/src/admin/components/Monitoring.tsx
@@ -4,6 +4,15 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import React from 'react';
 import CsvExports from './CsvExports';
+import StartedAndCompletedByAttribute from './StartedAndCompletedByAttribute';
 
-export default [CsvExports];
+// TODO Support more graphs: maybe instead of having all possible attribute
+// graph, have a dropdown to select the attribute? and add the graph to the
+// page? And add it to a user's preferences?
+const StartedAndCompletedByStrate: React.FC = () => (
+    <StartedAndCompletedByAttribute attributeName="strate" direction="vertical" />
+);
+
+export default [CsvExports, StartedAndCompletedByStrate];

--- a/survey/src/admin/components/StartedAndCompletedByAttribute.tsx
+++ b/survey/src/admin/components/StartedAndCompletedByAttribute.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BarChart, Bar, Rectangle, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+type StartedAndCompletedDataCategorized = {
+    category: string;
+    started: number;
+    completed: number;
+}[];
+
+type StartedAndCompletedByAttributeProps = {
+    attributeName: string;
+    direction?: 'horizontal' | 'vertical';
+};
+
+// Return configured axis for horizontal or vertical direction
+const ChartAxisAndLegend: React.FC<{ direction: 'horizontal' | 'vertical' }> = ({ direction }) => {
+    if (direction === 'vertical') {
+        return (
+            <React.Fragment>
+                <XAxis
+                    type="category"
+                    dataKey="category"
+                    height={60} // Increase height for rotated labels
+                    tickFormatter={(value) => value}
+                    angle={-45} // Rotate labels diagonally
+                    textAnchor="end" // Align text properly
+                    interval={0} // Show all labels
+                />
+                <YAxis />
+                <Legend verticalAlign="bottom" height={36} wrapperStyle={{ paddingTop: '10px' }} />
+            </React.Fragment>
+        );
+    } else {
+        return (
+            <React.Fragment>
+                <XAxis type="number" />
+                <YAxis type="category" dataKey="category" />
+                <Legend verticalAlign="bottom" />
+            </React.Fragment>
+        );
+    }
+};
+
+/**
+ * Generic component to show a bar chart of started and completed interviews by
+ * a given attribute
+ *
+ * @param attributeName the attribute by which to make the graph
+ * @returns A component with a bar chart for completed and started interview by
+ * the given attribute
+ */
+const StartedAndCompletedByAttribute: React.FC<StartedAndCompletedByAttributeProps> = ({
+    attributeName,
+    direction = 'vertical'
+}: StartedAndCompletedByAttributeProps) => {
+    const { t } = useTranslation();
+
+    const [data, setData] = useState<StartedAndCompletedDataCategorized>([]);
+
+    useEffect(() => {
+        fetch('/api/admin/data/startedCompletedByAttribute?attribute=' + encodeURIComponent(attributeName), {
+            method: 'GET',
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+            .then((response) => {
+                // TODO Handle errors better, currently, the graph is simply
+                // absent from the status page (returns null)
+                if (response.status === 200) {
+                    response
+                        .json()
+                        .then((jsonData) => {
+                            const dataForChart: StartedAndCompletedDataCategorized = [];
+                            const sortedCategories = Object.keys(jsonData.started).sort();
+                            for (let i = 0, count = sortedCategories.length; i < count; i++) {
+                                const category = sortedCategories[i];
+                                const completedCount = jsonData.completed[category] || 0;
+                                const completedRatio = completedCount / jsonData.started[category];
+                                // Translation strings can be added in the surveyAdmin.yml translation file with the key pattern: {attributeName}Categories: under which are the categories
+                                const translatedCategory = t(`surveyAdmin:${attributeName}Categories:${category}`, {
+                                    defaultValue: category
+                                });
+                                dataForChart.push({
+                                    category: `${translatedCategory} (${Math.round(completedRatio * 1000) / 10})%`,
+                                    started: jsonData.started[category],
+                                    completed: completedCount
+                                });
+                            }
+                            setData(dataForChart);
+                        })
+                        .catch((err) => {
+                            console.log('Error converting data to json.', err);
+                        });
+                }
+            })
+            .catch((err) => {
+                console.log('Error fetching data.', err);
+            });
+    }, []);
+
+    // FIXME Maybe we should still return a placeholder to show there is no data
+    if (data.length === 0) {
+        return null;
+    }
+
+    // Either constraint the width or height depending on the direction, to show
+    // all data
+    // FIXME Improve style when moving the Evolution. The horizontal chart takes
+    // full width of page, it should be bounded to something, but what?
+    const constrainedSize = Math.min(1600, Math.max(250, data.length * 30 + 150));
+    const divStyle =
+        direction === 'vertical'
+            ? { width: `${constrainedSize}px`, height: '100%' }
+            : { height: `${constrainedSize}px`, width: '100%' };
+
+    return (
+        <div className="admin-widget-container" style={divStyle}>
+            <p className="no-bottom-margin">
+                <strong>
+                    {t('surveyAdmin:StartedAndCompletedInterviewsPer', {
+                        attribute: t(`surveyAdmin:${attributeName}`, { defaultValue: attributeName })
+                    })}
+                </strong>
+            </p>
+            {/* Adjust height to make room for title and download link*/}
+            <ResponsiveContainer width="100%" height="85%">
+                <BarChart
+                    layout={direction === 'vertical' ? 'horizontal' : 'vertical'} // To have horizontal bar charts, layout has to be vertical
+                    width={500}
+                    height={300}
+                    data={data}
+                    margin={{
+                        top: 20, // Increased top margin to make room for the title
+                        right: 30,
+                        left: 20,
+                        bottom: 70
+                    }}
+                >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <ChartAxisAndLegend direction={direction} />
+                    <Tooltip />
+                    <Bar
+                        dataKey="started"
+                        name={t('admin:StartedFem')}
+                        fill="#A4DB4F"
+                        activeBar={<Rectangle stroke="blue" />}
+                    />
+                    <Bar
+                        dataKey="completed"
+                        name={t('admin:CompletedFem')}
+                        fill="#428626"
+                        activeBar={<Rectangle stroke="blue" />}
+                    />
+                </BarChart>
+            </ResponsiveContainer>
+            <a href={`/api/admin/data/startedCompletedByAttributeCsv?attribute=${encodeURIComponent(attributeName)}`}>
+                {t('surveyAdmin:CSV')}
+            </a>
+        </div>
+    );
+};
+
+export default StartedAndCompletedByAttribute;

--- a/survey/src/admin/monitoring.ts
+++ b/survey/src/admin/monitoring.ts
@@ -179,3 +179,29 @@ export const trackingData = async () => {
         return [];
     }
 };
+
+/**
+ * Counts the started and completed interviews by the values of a specific
+ * attribute
+ *
+ * @param attribute The attribute to group by (e.g., 'strate', 'lot',
+ * 'language', etc.)
+ * @returns An object with two properties: 'started' and 'completed', each
+ * containing a mapping of attribute values to counts.
+ */
+export const getStartedCompletedByAttribute = async (
+    attribute: string
+): Promise<{ started: Record<string, number>; completed: Record<string, number> }> => {
+    const data = await adminViewQueries.countByView(monitoringViewName, [attribute, 'survey_completed']);
+    const result = { started: {}, completed: {} };
+    if (data !== false) {
+        data.forEach((oneData) => {
+            const key = (oneData[attribute] ?? 'null') as string;
+            if (oneData.survey_completed === 1) {
+                result.completed[key] = oneData.count;
+            }
+            result.started[key] = (result.started[key] || 0) + oneData.count;
+        });
+    }
+    return result;
+};

--- a/survey/src/admin/routes/admin.routes.ts
+++ b/survey/src/admin/routes/admin.routes.ts
@@ -9,6 +9,52 @@ import moment from 'moment-timezone';
 import papaparse from 'papaparse';
 import * as monitoring from '../monitoring';
 
+const monitoringDataCall = async (req, res, next) => {
+    try {
+        if (!req.query.attribute) {
+            return res.status(400).json({ error: 'attribute query parameter is required' });
+        }
+        const attribute = req.query.attribute;
+        // FIXME Validate the attribute first? Otherwise, we count on sql
+        // failure if invalid. The attribute is properly escaped, so no sql
+        // injection possible, but still, not a good practice.
+        const startedCompletedByField = await monitoring.getStartedCompletedByAttribute(attribute);
+
+        return res.status(200).json(startedCompletedByField);
+    } catch (error) {
+        console.log('Error getting interview by attribute', error);
+        return res.status(500).json({ error: 'Error getting interview by attribute' });
+    }
+};
+
+const monitoringDataCallToCsv = async (req, res, next) => {
+    try {
+        if (!req.query.attribute) {
+            return res.status(400).json({ error: 'attribute query parameter is required' });
+        }
+        const attribute = req.query.attribute;
+        const startedCompletedByField = await monitoring.getStartedCompletedByAttribute(attribute);
+
+        const csvContent = [];
+        for (const attribute in startedCompletedByField.started) {
+            csvContent.push({
+                attribute,
+                started: startedCompletedByField.started[attribute],
+                completed: startedCompletedByField.completed[attribute]
+            });
+        }
+        res.setHeader(
+            'Content-disposition',
+            `attachment; filename=startedCompletedInterviewsBy${attribute}_${moment().format('YYYYMMDD')}.csv`
+        );
+        res.set('Content-Type', 'text/csv');
+        return res.status(200).send(papaparse.unparse(csvContent));
+    } catch (error) {
+        console.log('Error getting interview by attribute csv', error);
+        return res.status(500).json({ error: 'Error getting interview by attribute' });
+    }
+};
+
 // Registers admin monitoring routes.
 const loadRoutes = (router: Router): void => {
     // Update monitoring cache
@@ -45,6 +91,10 @@ const loadRoutes = (router: Router): void => {
             });
         }
     });
+
+    router.get('/data/startedCompletedByAttribute', monitoringDataCall);
+
+    router.get('/data/startedCompletedByAttributeCsv', monitoringDataCallToCsv);
 };
 
 export default loadRoutes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,6 +1868,18 @@
   resolved "https://registry.yarnpkg.com/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz#6b64177843a60c66e0ebaf85037a47ecd07007df"
   integrity sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==
 
+"@reduxjs/toolkit@1.x.x || 2.x.x":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.9.0.tgz#d4b12b90c27716a6a507193f8c3b2880729b97d5"
+  integrity sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@standard-schema/utils" "^0.3.0"
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1896,6 +1908,16 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
+"@standard-schema/spec@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@testing-library/dom@>=7":
   version "10.4.0"
@@ -3531,6 +3553,57 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
   integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
+"@types/d3-array@^3.0.3":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-ease@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-interpolate@^3.0.1":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-shape@^3.1.0":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.7.tgz#2b7b423dc2dfe69c8c93596e673e37443348c555"
+  integrity sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
 
 "@types/d3-voronoi@^1.1.12":
   version "1.1.12"
@@ -5677,12 +5750,83 @@ d3-array@1:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-ease@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
 d3-geo@1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
   integrity sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==
   dependencies:
     d3-array "1"
+
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-shape@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-timer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 d3-voronoi@1.1.2:
   version "1.1.2"
@@ -5784,6 +5928,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decimal.js-light@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 decimal.js@^10.4.2:
   version "10.4.3"
@@ -6359,6 +6508,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es-toolkit@^1.39.3:
+  version "1.39.10"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.10.tgz#513407af73e79f9940e7ec7650f2e6dceeaf1d81"
+  integrity sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==
+
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -6607,6 +6761,11 @@ eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 events@^3.2.0:
   version "3.3.0"
@@ -7659,6 +7818,11 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
+immer@^10.0.3, immer@^10.1.1:
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.3.tgz#e38a0b97db59949d31d9b381b04c2e441b1c3747"
+  integrity sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==
+
 immutable@^5.0.2:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.0.3.tgz#aa037e2313ea7b5d400cd9298fa14e404c933db1"
@@ -7761,6 +7925,11 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -11129,7 +11298,7 @@ react-modal@^3.16.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
-react-redux@^9.2.0:
+"react-redux@8.x.x || 9.x.x", react-redux@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
   integrity sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==
@@ -11279,6 +11448,23 @@ readdirp@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.2.tgz#388fccb8b75665da3abffe2d8f8ed59fe74c230a"
   integrity sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==
+
+recharts@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-3.2.1.tgz#a4dbf9b089404bd8e2fb74a9aa8a7679e413e2f0"
+  integrity sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==
+  dependencies:
+    "@reduxjs/toolkit" "1.x.x || 2.x.x"
+    clsx "^2.1.1"
+    decimal.js-light "^2.5.1"
+    es-toolkit "^1.39.3"
+    eventemitter3 "^5.0.1"
+    immer "^10.1.1"
+    react-redux "8.x.x || 9.x.x"
+    reselect "5.1.1"
+    tiny-invariant "^1.3.3"
+    use-sync-external-store "^1.2.2"
+    victory-vendor "^37.0.2"
 
 rechoir@^0.8.0:
   version "0.8.0"
@@ -11443,6 +11629,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+reselect@5.1.1, reselect@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -12508,6 +12699,11 @@ tiny-inflate@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
+tiny-invariant@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tiny-osmpbf@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tiny-osmpbf/-/tiny-osmpbf-0.1.0.tgz#0a895717113ebe6aae363c4be5eefa8ecdafb927"
@@ -12947,6 +13143,11 @@ use-isomorphic-layout-effect@^1.1.2:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
+use-sync-external-store@^1.2.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
+  integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+
 use-sync-external-store@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
@@ -13021,6 +13222,26 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+victory-vendor@^37.0.2:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-37.3.6.tgz#401ac4b029a0b3d33e0cba8e8a1d765c487254da"
+  integrity sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==
+  dependencies:
+    "@types/d3-array" "^3.0.3"
+    "@types/d3-ease" "^3.0.0"
+    "@types/d3-interpolate" "^3.0.1"
+    "@types/d3-scale" "^4.0.2"
+    "@types/d3-shape" "^3.1.0"
+    "@types/d3-time" "^3.0.0"
+    "@types/d3-timer" "^3.0.0"
+    d3-array "^3.1.6"
+    d3-ease "^3.0.1"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.1.0"
+    d3-time "^3.0.0"
+    d3-timer "^3.0.1"
 
 void-elements@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
part of #404

This adds the necessary backend requests and queries to retrieve the started and completed interviews by any supported attribute.

It adds a generic React component to display in a bar chart the started and completed interview by any attribute. The `attributeName` is passed as props. The backend route is called with this attribute and the series are thus built. To properly translate the attribute name and categories, the translation strings are in the `surveyAdmin.yml` file. There should be one that is the name of the attribute that will be displayed in the graph's title. And the categories are under a
`<attributeName>Categories` object.

Implement this for the `strate` attribute. The update translation file is as follows:

```
strateCategories:
  null: "Not specified"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin monitoring chart showing started vs. completed interviews by attribute (vertical/horizontal layouts), with CSV download and new endpoints powering the chart.
* **Chores**
  * Added charting dependency to support the new visualization.
* **Localization**
  * Added English and French labels for the new chart, including a “Not specified” category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->