### PR TITLE
Add parsers for audit

### DIFF
--- a/.cursor/rules/project-rule.mdc
+++ b/.cursor/rules/project-rule.mdc
@@ -205,3 +205,8 @@ When providing assistance, consider the multi-layered architecture (survey → e
 - No trailing spaces, even in comments/doc, no line with spaces only, replace with blank line
 - Use parentheses for arrow function params
 - Document non trivial functions and attributes, using jsdoc or inline comments when short
+- When creating tests, favor parametric tests when more than one expect is used, to simplify debugging of failed tests.
+- indent using 4 spaces. Read these prettier config to know how to format code:
+  - evolution/configs/base.eslintrc.json
+  - evolution/configs/gts.eslintrc.json
+  - evolution/configs/react.eslintrc.json

--- a/survey/config.js
+++ b/survey/config.js
@@ -8,7 +8,7 @@ moment.updateLocale('fr', {
     holidays,
     holidayFormat: 'YYYY-MM-DD',
     longDateFormat: {
-        LL: "dddd Do MMMM YYYY",
+        LL: 'dddd Do MMMM YYYY',
     }
 });
 
@@ -16,7 +16,7 @@ moment.updateLocale('en', {
     holidays,
     holidayFormat: 'YYYY-MM-DD',
     longDateFormat: {
-        LL: "dddd, MMMM Do YYYY",
+        LL: 'dddd, MMMM Do YYYY',
     }
 });
 
@@ -27,6 +27,9 @@ module.exports = Object.assign({
         fr: `/dist/images/logo_od_${survey}_2025_fr.svg`,
         en: `/dist/images/logo_od_${survey}_2025_en.svg`
     },
+    countryCode: 'CA',
+    startDate: '2025-09-02', // tuesday after Labor day
+    endDate: '2025-12-16',
     forceRecalculateTransitTrips: false,
     updateTransitRoutingIfCalculatedBefore: moment('2024-03-07').unix(), // timestamp, will recalculate transit trips if calculated before this date
     startButtonColor: 'turquoise', // styles for turquoise buttons are in the project's styles.scss file
@@ -73,15 +76,16 @@ module.exports = Object.assign({
         lat: 46.81289,
         lon: -71.21461
     },
+    mapAerialTilesUrl: undefined, // aerial imagery usually requires permission to use. Feel free to add your own url to this file in your local environment.
     mapMaxGeocodingResultsBounds: [
-      {
-        lat: 47.033374,
-        lng: -70.8030445
-      },
-      {
-        lat: 46.518331,
-        lng: -71.671425
-    }],
+        {
+            lat: 47.033374,
+            lng: -70.8030445
+        },
+        {
+            lat: 46.518331,
+            lng: -71.671425
+        }],
     detectLanguage: false,
     detectLanguageFromUrl: true,
     languages: ['fr', 'en'],
@@ -90,13 +94,13 @@ module.exports = Object.assign({
         en: 'en-CA'
     },
     languageNames: {
-        fr: "Français",
-        en: "English"
+        fr: 'Français',
+        en: 'English'
     },
     title: {
-        fr: "Enquête Nationale Origine-Destination 2025",
-        en: "2025 National Origin-Destination Survey"
+        fr: 'Enquête Nationale Origine-Destination 2025',
+        en: '2025 National Origin-Destination Survey'
     },
-    defaultLocale: "fr",
+    defaultLocale: 'fr',
     timezone: 'America/Montreal',
 }, variantSpecificConfig);

--- a/survey/src/admin/parsers/__tests__/home.parser.test.ts
+++ b/survey/src/admin/parsers/__tests__/home.parser.test.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { parseHomeAttributes } from '../home.parser';
+import { CorrectedResponse, InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
+describe('parseHomeAttributes', () => {
+    it('should convert flat address fields to Address object structure', () => {
+        const homeAttributes = {
+            address: '123 Main Street',
+            city: 'Montreal',
+            region: 'Quebec',
+            country: 'Canada',
+            postalCode: 'H1A 1A1'
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '123 Main Street',
+                municipalityName: 'Montreal',
+                region: 'Quebec',
+                country: 'Canada',
+                postalCode: 'H1A 1A1'
+            }
+        });
+    });
+
+    it('should handle partial address data', () => {
+        const homeAttributes = {
+            address: '456 Oak Avenue',
+            city: 'Toronto'
+            // Missing region, country, postalCode
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '456 Oak Avenue',
+                municipalityName: 'Toronto'
+            }
+        });
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['string', 'string'],
+        ['number', 123],
+        ['boolean', true]
+    ])('should handle %s homeAttributes gracefully', (_description, homeAttributes) => {
+        expect(() => parseHomeAttributes(homeAttributes as any, { uuid: 'test' } as CorrectedResponse)).not.toThrow();
+    });
+
+    it('should handle home object without address fields', () => {
+        const homeAttributes = {
+            someOtherField: 'value',
+            anotherField: 42
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            someOtherField: 'value',
+            anotherField: 42
+        });
+    });
+
+    it('should preserve other home fields when converting address', () => {
+        const homeAttributes = {
+            address: '789 Pine Street',
+            city: 'Vancouver',
+            region: 'British Columbia',
+            someOtherField: 'preserved',
+            anotherField: 42,
+            nestedObject: {
+                property: 'value'
+            }
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '789 Pine Street',
+                municipalityName: 'Vancouver',
+                region: 'British Columbia'
+            },
+            someOtherField: 'preserved',
+            anotherField: 42,
+            nestedObject: {
+                property: 'value'
+            }
+        });
+    });
+
+    test.each([
+        [
+            'only address field present',
+            { address: '100 Test Street' },
+            { address: { fullAddress: '100 Test Street' } }
+        ],
+        [
+            'only city field present',
+            { city: 'Quebec City' },
+            { address: { municipalityName: 'Quebec City' } }
+        ]
+    ])('should handle %s', (description, homeAttributes, expected) => {
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle only region, country, and postalCode without address or city', () => {
+        const homeAttributes = {
+            region: 'Ontario',
+            country: 'Canada',
+            postalCode: 'K1A 0A6'
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                region: 'Ontario',
+                country: 'Canada',
+                postalCode: 'K1A 0A6'
+            }
+        });
+    });
+
+    test.each([
+        [
+            'empty string values',
+            {
+                address: '',
+                city: 'Montreal',
+                region: '',
+                country: 'Canada',
+                postalCode: ''
+            },
+            {
+                address: {
+                    municipalityName: 'Montreal',
+                    country: 'Canada'
+                }
+            }
+        ],
+        [
+            'null and undefined field values',
+            {
+                address: null,
+                city: 'Toronto',
+                region: undefined,
+                country: 'Canada',
+                postalCode: null
+            },
+            {
+                address: {
+                    municipalityName: 'Toronto',
+                    country: 'Canada'
+                }
+            }
+        ]
+    ])('should handle %s', (description, homeAttributes, expected) => {
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+        expect(result).toEqual(expected);
+    });
+
+    it('should work with interview attributes parameter (though not used)', () => {
+        const homeAttributes = {
+            address: '123 Test Street',
+            city: 'Montreal'
+        };
+
+        const interviewAttributes: InterviewAttributes = {
+            uuid: 'test-interview-uuid',
+            corrected_response: {
+                _language: 'fr'
+            }
+        } as any;
+
+        const result = parseHomeAttributes(homeAttributes, interviewAttributes);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '123 Test Street',
+                municipalityName: 'Montreal'
+            }
+        });
+    });
+
+    it('should handle complex address scenarios', () => {
+        const homeAttributes = {
+            address: '1234 Rue Sainte-Catherine Ouest, Apt 5B',
+            city: 'Montréal',
+            region: 'Québec',
+            country: 'Canada',
+            postalCode: 'H3G 1P1',
+            homeType: 'apartment',
+            yearBuilt: 1985,
+            numberOfRooms: 4
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '1234 Rue Sainte-Catherine Ouest, Apt 5B',
+                municipalityName: 'Montréal',
+                region: 'Québec',
+                country: 'Canada',
+                postalCode: 'H3G 1P1'
+            },
+            homeType: 'apartment',
+            yearBuilt: 1985,
+            numberOfRooms: 4
+        });
+    });
+
+    it('should handle address fields with different data types', () => {
+        const homeAttributes = {
+            address: 123, // Number instead of string
+            city: 'Montreal',
+            region: true, // Boolean instead of string
+            country: 'Canada',
+            postalCode: 'H1A, 1A1' // Array instead of string
+        };
+
+        const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+        expect(result).toEqual({
+            address: {
+                fullAddress: '123',
+                municipalityName: 'Montreal',
+                region: 'true',
+                country: 'Canada',
+                postalCode: 'H1A, 1A1'
+            }
+        });
+    });
+
+    // Immutability tests
+    describe('immutability', () => {
+        it('should not modify the original homeAttributes object', () => {
+            const originalHomeAttributes = {
+                address: '123 Main Street',
+                city: 'Montreal',
+                region: 'Quebec',
+                country: 'Canada',
+                postalCode: 'H1A 1A1',
+                someOtherField: 'preserved'
+            };
+
+            // Create a deep copy to compare against
+            const originalCopy = JSON.parse(JSON.stringify(originalHomeAttributes));
+
+            const result = parseHomeAttributes(originalHomeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+            // Original should remain unchanged
+            expect(originalHomeAttributes).toEqual(originalCopy);
+
+            // Result should be different from original
+            expect(result).not.toEqual(originalHomeAttributes);
+            expect(result).toEqual({
+                address: {
+                    fullAddress: '123 Main Street',
+                    municipalityName: 'Montreal',
+                    region: 'Quebec',
+                    country: 'Canada',
+                    postalCode: 'H1A 1A1'
+                },
+                someOtherField: 'preserved'
+            });
+        });
+
+        it('should not modify the correctedResponse parameter', () => {
+            const homeAttributes = {
+                address: '456 Oak Avenue',
+                city: 'Toronto'
+            };
+
+            const originalCorrectedResponse = { uuid: 'test', someField: 'value' };
+            const correctedResponseCopy = JSON.parse(JSON.stringify(originalCorrectedResponse));
+
+            parseHomeAttributes(homeAttributes, originalCorrectedResponse as CorrectedResponse);
+
+            // correctedResponse should remain unchanged
+            expect(originalCorrectedResponse).toEqual(correctedResponseCopy);
+        });
+
+        it('should handle nested objects without modifying originals', () => {
+            const homeAttributes = {
+                address: '789 Pine Street',
+                city: 'Vancouver',
+                nestedObject: {
+                    property: 'value',
+                    deepNested: {
+                        level: 2
+                    }
+                }
+            };
+
+            const originalCopy = JSON.parse(JSON.stringify(homeAttributes));
+
+            const result = parseHomeAttributes(homeAttributes, { uuid: 'test' } as CorrectedResponse);
+
+            // Original should remain unchanged
+            expect(homeAttributes).toEqual(originalCopy);
+
+            // Result should have processed address but preserved nested structure
+            expect(result.nestedObject).toEqual({
+                property: 'value',
+                deepNested: {
+                    level: 2
+                }
+            });
+            expect(result.nestedObject).not.toBe(homeAttributes.nestedObject); // Different reference
+        });
+    });
+});

--- a/survey/src/admin/parsers/__tests__/interview.parser.test.ts
+++ b/survey/src/admin/parsers/__tests__/interview.parser.test.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { parseInterviewAttributes } from '../interview.parser';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+
+describe('parseInterviewAttributes', () => {
+    describe('acceptToBeContactedForHelp conversion', () => {
+        test.each([
+            ['yes', true],
+            ['no', false],
+            ['saperlipopette', undefined] // anything else should revert to undefined
+        ])('should convert acceptToBeContactedForHelp from "%s" to %s', (input, expected) => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: input
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            if (expected === undefined) {
+                expect(result.acceptToBeContactedForHelp).toBeUndefined();
+            } else {
+                expect(result.acceptToBeContactedForHelp).toBe(expected);
+            }
+        });
+
+        it('should handle undefined acceptToBeContactedForHelp', () => {
+            const correctedResponse: CorrectedResponse = {};
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            expect(result.acceptToBeContactedForHelp).toBeUndefined();
+        });
+    });
+
+    describe('wouldLikeToParticipateInOtherSurveys conversion', () => {
+        test.each([
+            ['yes', true],
+            ['no', false],
+            ['toaster', undefined] // anything else should revert to undefined
+        ])('should convert wouldLikeToParticipateInOtherSurveys from "%s" to %s', (input, expected) => {
+            const correctedResponse: CorrectedResponse = {
+                wouldLikeToParticipateInOtherSurveys: input
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            if (expected === undefined) {
+                expect(result.wouldLikeToParticipateInOtherSurveys).toBeUndefined();
+            } else {
+                expect(result.wouldLikeToParticipateInOtherSurveys).toBe(expected);
+            }
+        });
+
+        it('should handle undefined wouldLikeToParticipateInOtherSurveys', () => {
+            const correctedResponse: CorrectedResponse = {};
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            expect(result.wouldLikeToParticipateInOtherSurveys).toBeUndefined();
+        });
+    });
+
+    describe('assignedDate conversion', () => {
+        it('should convert _assignedDay to assignedDate', () => {
+            const correctedResponse: CorrectedResponse = {
+                _assignedDay: '2025-01-15'
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            expect(result.assignedDate).toBe('2025-01-15');
+            expect(result._assignedDay).toBe('2025-01-15'); // Should preserve original
+        });
+
+        it('should handle missing _assignedDay', () => {
+            const correctedResponse: CorrectedResponse = {};
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            expect(result.assignedDate).toBeUndefined();
+        });
+    });
+
+    describe('error handling', () => {
+        test.each([
+            ['null', null],
+            ['undefined', undefined]
+        ])('should handle %s corrected_response gracefully', (description, correctedResponse) => {
+            expect(() => parseInterviewAttributes(correctedResponse as any)).not.toThrow();
+
+            // Should not crash and leave attributes unchanged
+            if (description === 'null') {
+                expect(correctedResponse).toBeNull();
+            } else {
+                expect(correctedResponse).toBeUndefined();
+            }
+        });
+    });
+
+    describe('comprehensive parsing', () => {
+        it('should preserve other attributes when parsing', () => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                wouldLikeToParticipateInOtherSurveys: 'no',
+                _assignedDay: '2025-01-15',
+                _language: 'fr',
+                household: {
+                    size: 3
+                }
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            // Should parse the target attributes
+            expect(result.acceptToBeContactedForHelp).toBe(true);
+            expect(result.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result.assignedDate).toBe('2025-01-15');
+            expect(result._languages).toEqual(['fr']);
+
+            // Should preserve other attributes
+            expect(result.household?.size).toBe(3);
+        });
+
+        it('should handle all conversions simultaneously', () => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                wouldLikeToParticipateInOtherSurveys: 'no',
+                _assignedDay: '2025-02-01',
+                _language: 'en',
+                household: {
+                    size: 3
+                }
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            // Should parse the target attributes
+            expect(result.acceptToBeContactedForHelp).toBe(true);
+            expect(result.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result.assignedDate).toBe('2025-02-01');
+            expect(result._languages).toEqual(['en']);
+
+            // Should preserve other attributes
+            expect(result._assignedDay).toBe('2025-02-01');
+            expect(result.household?.size).toBe(3);
+        });
+    });
+
+    describe('edge cases and performance', () => {
+        it('should handle concurrent parser calls', () => {
+            const correctedResponse1: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes'
+            };
+
+            const correctedResponse2: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'no'
+            };
+
+            // Simulate concurrent parsing
+            const result1 = parseInterviewAttributes(correctedResponse1);
+            const result2 = parseInterviewAttributes(correctedResponse2);
+
+            expect(result1.acceptToBeContactedForHelp).toBe(true);
+            expect(result2.acceptToBeContactedForHelp).toBe(false);
+        });
+
+        it('should handle repeated parsing correctly', () => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                wouldLikeToParticipateInOtherSurveys: 'no',
+                _language: 'fr'
+            };
+
+            // First parsing should convert 'yes' to true, 'no' to false, and add languages array
+            const result1 = parseInterviewAttributes(correctedResponse);
+            expect(result1.acceptToBeContactedForHelp).toBe(true);
+            expect(result1.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result1._languages).toEqual(['fr']);
+
+            // Second parsing should leave values unchanged (idempotent)
+            const result2 = parseInterviewAttributes(result1);
+            expect(result2.acceptToBeContactedForHelp).toBe(true);
+            expect(result2.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result2._languages).toEqual(['fr']);
+
+            // Third parsing should still leave values unchanged
+            const result3 = parseInterviewAttributes(result2);
+            expect(result3.acceptToBeContactedForHelp).toBe(true);
+            expect(result3.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result3._languages).toEqual(['fr']);
+        });
+
+        it('should not create memory leaks with large datasets', () => {
+            // Create a large interview structure
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                wouldLikeToParticipateInOtherSurveys: 'no',
+                _assignedDay: '2025-01-15',
+                _language: 'en',
+                household: {
+                    persons: {}
+                }
+            };
+
+            const result = parseInterviewAttributes(correctedResponse);
+
+            expect(result.acceptToBeContactedForHelp).toBe(true);
+            expect(result.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result.assignedDate).toBe('2025-01-15');
+            expect(result._languages).toEqual(['en']);
+            expect(result.household?.persons).toEqual({});
+
+            // Add many persons to test memory usage
+            for (let i = 0; i < 100; i++) {
+                result.household!.persons![`person-${i}`] = {
+                    _uuid: `person-${i}`,
+                    _sequence: i,
+                    age: 25 + i
+                };
+            }
+
+            // Test that the parser works correctly even after adding large dataset
+            // and that repeated parsing doesn't cause issues (idempotent)
+            const result2 = parseInterviewAttributes(result);
+            expect(result2.acceptToBeContactedForHelp).toBe(true);
+            expect(result2.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result2.assignedDate).toBe('2025-01-15');
+            expect(result2._languages).toEqual(['en']);
+        });
+    });
+});

--- a/survey/src/admin/parsers/__tests__/parsers.test.ts
+++ b/survey/src/admin/parsers/__tests__/parsers.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { parseInterviewAttributes } from '../interview.parser';
+import { parseHomeAttributes } from '../home.parser';
+import { parseTripAttributes } from '../trip.parser';
+import { parseVisitedPlaceAttributes } from '../visitedPlace.parser';
+import { surveyObjectParsers } from '../index';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { ExtendedTripAttributes } from 'evolution-common/lib/services/baseObjects/Trip';
+import { ExtendedVisitedPlaceAttributes } from 'evolution-common/lib/services/baseObjects/VisitedPlace';
+
+describe('OD Nationale Quebec Survey Parsers', () => {
+
+    describe('Survey-Specific Parser Configuration', () => {
+        test.each([
+            ['interview', parseInterviewAttributes],
+            ['home', parseHomeAttributes],
+            ['trip', parseTripAttributes],
+            ['visitedPlace', parseVisitedPlaceAttributes]
+        ])('should have %s parser configured correctly', (parserName, expectedFunction) => {
+            expect(surveyObjectParsers[parserName as keyof typeof surveyObjectParsers]).toBeDefined();
+            expect(typeof surveyObjectParsers[parserName as keyof typeof surveyObjectParsers]).toBe('function');
+            expect(surveyObjectParsers[parserName as keyof typeof surveyObjectParsers]).toBe(expectedFunction);
+        });
+
+        test.each([
+            'household',
+            'person',
+            'journey',
+            'segment'
+        ])('should not have %s parser (unused in this survey)', (parserName) => {
+            expect(surveyObjectParsers[parserName as keyof typeof surveyObjectParsers]).toBeUndefined();
+        });
+    });
+
+    describe('Survey-Specific Parser Behavior', () => {
+        it('should handle OD Nationale Quebec interview fields correctly', () => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                wouldLikeToParticipateInOtherSurveys: 'no',
+                _assignedDay: '2025-01-15'
+            };
+
+            const result = surveyObjectParsers.interview!(correctedResponse);
+
+            // Verify OD Nationale Quebec specific conversions
+            expect(result.acceptToBeContactedForHelp).toBe(true);
+            expect(result.wouldLikeToParticipateInOtherSurveys).toBe(false);
+            expect(result.assignedDate).toBe('2025-01-15');
+        });
+
+        it('should handle Quebec address formats correctly', () => {
+            const homeAttributes = {
+                address: '1234 Rue Sainte-Catherine Ouest, Apt 5B',
+                city: 'Montréal',
+                region: 'Québec',
+                country: 'Canada',
+                postalCode: 'H3G 1P1'
+            };
+
+            const correctedResponse: CorrectedResponse = {};
+
+            const result = surveyObjectParsers.home!(homeAttributes, correctedResponse);
+
+            expect(result).toEqual({
+                address: {
+                    fullAddress: '1234 Rue Sainte-Catherine Ouest, Apt 5B',
+                    municipalityName: 'Montréal',
+                    region: 'Québec',
+                    country: 'Canada',
+                    postalCode: 'H3G 1P1'
+                }
+            });
+        });
+
+        it('should handle travel survey time assignments correctly', () => {
+            const correctedResponse: CorrectedResponse = {
+                _assignedDay: '2025-01-15'
+            };
+
+            const tripAttributes: ExtendedTripAttributes = {
+                _uuid: 'test-trip-uuid',
+                departureTime: 28800, // 8:00 AM
+                arrivalTime: 32400    // 9:00 AM
+            };
+
+            const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+                _uuid: 'test-visited-place-uuid',
+                arrivalTime: 32400,   // 9:00 AM
+                departureTime: 36000  // 10:00 AM
+            };
+
+            // Parse objects as they would be in the survey
+            const tripResult = surveyObjectParsers.trip!(tripAttributes, correctedResponse);
+            const visitedPlaceResult = surveyObjectParsers.visitedPlace!(visitedPlaceAttributes, correctedResponse);
+
+            // Verify time assignments for travel survey
+            expect(tripResult.startTime).toBe(28800);
+            expect(tripResult.endTime).toBe(32400);
+            expect(tripResult.startDate).toBe('2025-01-15');
+            expect(tripResult.endDate).toBe('2025-01-15');
+
+            expect(visitedPlaceResult.startTime).toBe(32400);
+            expect(visitedPlaceResult.endTime).toBe(36000);
+            expect(visitedPlaceResult.startDate).toBe('2025-01-15');
+            expect(visitedPlaceResult.endDate).toBe('2025-01-15');
+        });
+    });
+
+    describe('Survey Configuration Validation', () => {
+        test.each([
+            ['interview', parseInterviewAttributes],
+            ['home', parseHomeAttributes],
+            ['trip', parseTripAttributes],
+            ['visitedPlace', parseVisitedPlaceAttributes]
+        ])('should use correct parser implementation for %s', (parserName, expectedFunction) => {
+            expect(surveyObjectParsers[parserName as keyof typeof surveyObjectParsers]).toBe(expectedFunction);
+        });
+
+        it('should have correct parser configuration for OD Nationale Quebec survey', () => {
+            // Verify we have exactly the parsers we need for this survey
+            const expectedParsers = ['interview', 'home', 'trip', 'visitedPlace'];
+            const actualParsers = Object.keys(surveyObjectParsers).filter((key) =>
+                surveyObjectParsers[key as keyof typeof surveyObjectParsers] !== undefined
+            );
+
+            expect(actualParsers.sort()).toEqual(expectedParsers.sort());
+        });
+    });
+
+    describe('Survey Data Flow Integration', () => {
+        it('should handle complete OD survey data flow', () => {
+            // Simulate a complete OD survey response
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                _assignedDay: '2025-01-15'
+            };
+
+            const homeAttributes = {
+                address: '123 Rue de la Paix',
+                city: 'Québec',
+                region: 'Québec',
+                postalCode: 'G1R 2B5'
+            };
+
+            const tripAttributes: ExtendedTripAttributes = {
+                _uuid: 'od-trip-uuid',
+                departureTime: 25200, // 7:00 AM
+                arrivalTime: 27000,   // 7:30 AM
+                mode: 'transit',
+                purpose: 'work'
+            };
+
+            // Parse as would happen in the survey system
+            const interviewResult = surveyObjectParsers.interview!(correctedResponse);
+            const homeResult = surveyObjectParsers.home!(homeAttributes, correctedResponse);
+            const tripResult = surveyObjectParsers.trip!(tripAttributes, correctedResponse);
+
+            // Verify complete data flow
+            expect(interviewResult.acceptToBeContactedForHelp).toBe(true);
+            expect(interviewResult.assignedDate).toBe('2025-01-15');
+
+            expect(homeResult).toEqual({
+                address: {
+                    fullAddress: '123 Rue de la Paix',
+                    municipalityName: 'Québec',
+                    region: 'Québec',
+                    postalCode: 'G1R 2B5'
+                }
+            });
+
+            expect(tripResult.startTime).toBe(25200);
+            expect(tripResult.endTime).toBe(27000);
+            expect(tripResult.startDate).toBe('2025-01-15');
+            expect(tripResult.mode).toBe('transit');
+            expect(tripResult.purpose).toBe('work');
+        });
+
+        it('should preserve survey-specific fields during parsing', () => {
+            const correctedResponse: CorrectedResponse = {
+                acceptToBeContactedForHelp: 'yes',
+                _assignedDay: '2025-01-15',
+                // Survey-specific fields that should be preserved
+                surveyVersion: '2025.1',
+                dataCollectionMethod: 'web',
+                completionTime: 1800
+            };
+
+            const originalSurveyVersion = correctedResponse.surveyVersion;
+            const originalDataCollectionMethod = correctedResponse.dataCollectionMethod;
+            const originalCompletionTime = correctedResponse.completionTime;
+
+            const result = surveyObjectParsers.interview!(correctedResponse);
+
+            // Verify survey-specific fields are preserved
+            expect(result.surveyVersion).toBe(originalSurveyVersion);
+            expect(result.dataCollectionMethod).toBe(originalDataCollectionMethod);
+            expect(result.completionTime).toBe(originalCompletionTime);
+
+            // Verify parsing still worked
+            expect(result.acceptToBeContactedForHelp).toBe(true);
+        });
+    });
+});

--- a/survey/src/admin/parsers/__tests__/trip.parser.test.ts
+++ b/survey/src/admin/parsers/__tests__/trip.parser.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { parseTripAttributes } from '../trip.parser';
+import { ExtendedTripAttributes } from 'evolution-common/lib/services/baseObjects/Trip';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+
+describe('parseTripAttributes', () => {
+    test.each([
+        [
+            'startTime and endTime from departureTime and arrivalTime',
+            { departureTime: 28800, arrivalTime: 32400 },
+            { startTime: 28800, endTime: 32400 }
+        ]
+    ])('should update %s', (description, tripData, expectedFields) => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            ...tripData
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedTripAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    it('should update startDate and endDate from _assignedDay', () => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            departureTime: 28800,
+            arrivalTime: 32400
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        expect(result.startDate).toBe('2025-01-15');
+        expect(result.endDate).toBe('2025-01-15');
+    });
+
+    test.each([
+        [
+            'missing departureTime',
+            { arrivalTime: 32400 },
+            { startTime: undefined, endTime: 32400 }
+        ],
+        [
+            'missing arrivalTime',
+            { departureTime: 28800 },
+            { startTime: 28800, endTime: undefined }
+        ]
+    ])('should handle %s gracefully', (description, tripData, expectedFields) => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            ...tripData
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedTripAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    test.each([
+        [
+            'missing _assignedDay',
+            {},
+            { startTime: 28800, endTime: 32400, startDate: undefined, endDate: undefined }
+        ]
+    ])('should handle %s', (description, correctedResponseData, expectedFields) => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            departureTime: 28800,
+            arrivalTime: 32400
+        };
+
+        const correctedResponse: CorrectedResponse = correctedResponseData;
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedTripAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    it('should preserve other trip attributes', () => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            _sequence: 1,
+            departureTime: 28800,
+            arrivalTime: 32400,
+            mode: 'transit',
+            purpose: 'work',
+            origin_geography: {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-73.5673, 45.5017]
+                },
+                properties: {}
+            },
+            destination_geography: {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-73.5500, 45.5100]
+                },
+                properties: {}
+            }
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        // Should update time/date fields
+        expect(result.startTime).toBe(28800);
+        expect(result.endTime).toBe(32400);
+        expect(result.startDate).toBe('2025-01-15');
+        expect(result.endDate).toBe('2025-01-15');
+
+        // Should preserve other attributes
+        expect(result._uuid).toBe('test-trip-uuid');
+        expect(result._sequence).toBe(1);
+        expect(result.mode).toBe('transit');
+        expect(result.purpose).toBe('work');
+        expect(result.origin_geography).toBeDefined();
+        expect(result.destination_geography).toBeDefined();
+    });
+
+    it('should handle zero values for times correctly', () => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            departureTime: 0, // Midnight
+            arrivalTime: 0
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        expect(result.startTime).toBe(0);
+        expect(result.endTime).toBe(0);
+    });
+
+    it('should handle null corrected_response gracefully', () => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            departureTime: 28800,
+            arrivalTime: 32400
+        };
+
+        const correctedResponse: CorrectedResponse = null as unknown as CorrectedResponse;
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+        expect(result.startTime).toBe(28800);
+        expect(result.endTime).toBe(32400);
+        expect(result.startDate).toBeUndefined();
+        expect(result.endDate).toBeUndefined();
+    });
+
+    it('should handle complex trip scenarios', () => {
+        const tripAttributes: ExtendedTripAttributes = {
+            _uuid: 'test-trip-uuid',
+            _sequence: 2,
+            departureTime: 61200, // 5:00 PM
+            arrivalTime: 63000, // 5:30 PM
+            mode: 'carDriver',
+            purpose: 'shopping'
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-20',
+        };
+
+        const result = parseTripAttributes(tripAttributes, correctedResponse);
+
+        expect(result.startTime).toBe(61200);
+        expect(result.endTime).toBe(63000);
+        expect(result.startDate).toBe('2025-01-20');
+        expect(result.endDate).toBe('2025-01-20');
+        expect(result.mode).toBe('carDriver');
+        expect(result.purpose).toBe('shopping');
+    });
+});

--- a/survey/src/admin/parsers/__tests__/visitedPlace.parser.test.ts
+++ b/survey/src/admin/parsers/__tests__/visitedPlace.parser.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { parseVisitedPlaceAttributes } from '../visitedPlace.parser';
+import { ExtendedVisitedPlaceAttributes } from 'evolution-common/lib/services/baseObjects/VisitedPlace';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+
+describe('parseVisitedPlaceAttributes', () => {
+    test.each([
+        [
+            'startTime from arrivalTime',
+            { arrivalTime: 28800, departureTime: 32400 },
+            { startTime: 28800, endTime: 32400 }
+        ],
+        [
+            'endTime from departureTime',
+            { arrivalTime: 28800, departureTime: 32400 },
+            { startTime: 28800, endTime: 32400 }
+        ]
+    ])('should update %s', (description, visitedPlaceData, expectedFields) => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            ...visitedPlaceData
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedVisitedPlaceAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    it('should update startDate and endDate from _assignedDay', () => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            arrivalTime: 28800,
+            departureTime: 32400
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+
+        expect(result.startDate).toBe('2025-01-15');
+        expect(result.endDate).toBe('2025-01-15');
+    });
+
+    test.each([
+        [
+            'missing arrivalTime',
+            { departureTime: 32400 },
+            { startTime: undefined, endTime: 32400 }
+        ],
+        [
+            'missing departureTime',
+            { arrivalTime: 28800 },
+            { startTime: 28800, endTime: undefined }
+        ]
+    ])('should handle %s gracefully', (description, visitedPlaceData, expectedFields) => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            ...visitedPlaceData
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedVisitedPlaceAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    test.each([
+        [
+            'missing corrected_response',
+            {},
+            { startTime: 28800, endTime: 32400, startDate: undefined, endDate: undefined }
+        ],
+        [
+            'missing _assignedDay',
+            {},
+            { startTime: 28800, endTime: 32400, startDate: undefined, endDate: undefined }
+        ]
+    ])('should handle %s', (description, correctedResponseData, expectedFields) => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            arrivalTime: 28800,
+            departureTime: 32400
+        };
+
+        const correctedResponse: CorrectedResponse = correctedResponseData;
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+        Object.keys(expectedFields).forEach((key) => {
+            expect(result[key as keyof ExtendedVisitedPlaceAttributes]).toBe(expectedFields[key as keyof typeof expectedFields]);
+        });
+    });
+
+    it('should preserve other visitedPlace attributes', () => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            _sequence: 1,
+            arrivalTime: 28800,
+            departureTime: 32400,
+            activity: 'work',
+            geography: {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-73.5673, 45.5017]
+                },
+                properties: {}
+            }
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+
+        // Should update time/date fields
+        expect(result.startTime).toBe(28800);
+        expect(result.endTime).toBe(32400);
+        expect(result.startDate).toBe('2025-01-15');
+        expect(result.endDate).toBe('2025-01-15');
+
+        // Should preserve other attributes
+        expect(result._uuid).toBe('test-visited-place-uuid');
+        expect(result._sequence).toBe(1);
+        expect(result.activity).toBe('work');
+        expect(result.geography).toBeDefined();
+    });
+
+    it('should handle zero values for times correctly', () => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            arrivalTime: 0, // Midnight
+            departureTime: 0
+        };
+
+        const correctedResponse: CorrectedResponse = {
+            _assignedDay: '2025-01-15'
+        };
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+
+        expect(result.startTime).toBe(0);
+        expect(result.endTime).toBe(0);
+    });
+
+    it('should handle null corrected_response gracefully', () => {
+        const visitedPlaceAttributes: ExtendedVisitedPlaceAttributes = {
+            _uuid: 'test-visited-place-uuid',
+            arrivalTime: 28800,
+            departureTime: 32400
+        };
+
+        const correctedResponse = null as unknown as CorrectedResponse;
+
+        const result = parseVisitedPlaceAttributes(visitedPlaceAttributes, correctedResponse);
+        expect(result.startTime).toBe(28800);
+        expect(result.endTime).toBe(32400);
+        expect(result.startDate).toBeUndefined();
+        expect(result.endDate).toBeUndefined();
+    });
+});

--- a/survey/src/admin/parsers/home.parser.ts
+++ b/survey/src/admin/parsers/home.parser.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { AddressAttributes } from 'evolution-common/lib/services/baseObjects/Address';
+import { SurveyObjectParser } from 'evolution-backend/lib/services/audits/types';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { ExtendedPlaceAttributes } from 'evolution-common/lib/services/baseObjects/Place';
+import _cloneDeep from 'lodash/cloneDeep';
+
+/**
+ * Transforms flat home address fields into a nested Address object structure.
+ * Converts address → fullAddress, city → municipalityName, and preserves region, country, postalCode.
+ * Only creates the address object if at least fullAddress or municipalityName is present.
+ *
+ * @param originalCorrectedHomeAttributes - The home attributes to parse
+ * @param correctedResponse - The corrected response
+ * @returns ExtendedPlaceAttributes with nested address object if applicable
+ */
+export const parseHomeAttributes: SurveyObjectParser<ExtendedPlaceAttributes, CorrectedResponse> = (
+    originalCorrectedHomeAttributes: Readonly<ExtendedPlaceAttributes>,
+    _correctedResponse?: Readonly<CorrectedResponse>
+): ExtendedPlaceAttributes => {
+    const homeAttributes = _cloneDeep(originalCorrectedHomeAttributes) as ExtendedPlaceAttributes;
+
+    if (!homeAttributes || typeof homeAttributes !== 'object') {
+        return homeAttributes;
+    }
+
+    // Check if we have address-related fields to convert
+    const hasAddressFields =
+        homeAttributes.address ||
+        homeAttributes.city ||
+        homeAttributes.region ||
+        homeAttributes.country ||
+        homeAttributes.postalCode;
+
+    if (!hasAddressFields) {
+        return homeAttributes;
+    }
+
+    // Create address object from flat fields
+    const addressData: AddressAttributes = {};
+
+    const keys = Object.keys(homeAttributes);
+
+    // Map flat address fields to Address object structure
+    if (keys.includes('address')) {
+        // For now, put the address string in address.fullAddress
+        // TODO: In a more sophisticated parser, you might parse civic number, street name, etc.
+        addressData.fullAddress =
+            homeAttributes.address && homeAttributes.address !== '' ? String(homeAttributes.address) : undefined;
+        delete homeAttributes.address;
+    }
+
+    if (keys.includes('city')) {
+        addressData.municipalityName =
+            homeAttributes.city && homeAttributes.city !== '' ? String(homeAttributes.city) : undefined;
+        delete homeAttributes.city;
+    }
+
+    if (keys.includes('region')) {
+        addressData.region =
+            homeAttributes.region && homeAttributes.region !== '' ? String(homeAttributes.region) : undefined;
+        delete homeAttributes.region;
+    }
+
+    if (keys.includes('country')) {
+        addressData.country =
+            homeAttributes.country && homeAttributes.country !== '' ? String(homeAttributes.country) : undefined;
+        delete homeAttributes.country;
+    }
+
+    if (keys.includes('postalCode')) {
+        addressData.postalCode =
+            homeAttributes.postalCode && homeAttributes.postalCode !== ''
+                ? String(homeAttributes.postalCode)
+                : undefined;
+        delete homeAttributes.postalCode;
+    }
+
+    // Set the address object with the structured data
+    homeAttributes.address = addressData;
+
+    return homeAttributes;
+};

--- a/survey/src/admin/parsers/index.ts
+++ b/survey/src/admin/parsers/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { SurveyObjectParsers } from 'evolution-backend/lib/services/audits/types';
+import { parseInterviewAttributes } from './interview.parser';
+import { parseHomeAttributes } from './home.parser';
+import { parseVisitedPlaceAttributes } from './visitedPlace.parser';
+import { parseTripAttributes } from './trip.parser';
+
+/**
+ * Survey object parsers configuration.
+ * These parsers convert string choice values to proper types before object validation.
+ */
+export const surveyObjectParsers: SurveyObjectParsers = {
+    interview: parseInterviewAttributes,
+    home: parseHomeAttributes,
+    // household: parseHouseholdAttributes
+    // person: parsePersonAttributes,
+    // journey: parseJourneyAttributes,
+    visitedPlace: parseVisitedPlaceAttributes,
+    trip: parseTripAttributes
+    // segment: parseSegmentAttributes
+};

--- a/survey/src/admin/parsers/interview.parser.ts
+++ b/survey/src/admin/parsers/interview.parser.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { SurveyObjectParserInterview } from 'evolution-backend/lib/services/audits/types';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import _cloneDeep from 'lodash/cloneDeep';
+
+/**
+ * @param originalCorrectedResponse - The corrected response
+ */
+export const parseInterviewAttributes: SurveyObjectParserInterview<CorrectedResponse> = (
+    originalCorrectedResponse: Readonly<CorrectedResponse>
+): CorrectedResponse => {
+    const correctedResponse = _cloneDeep(originalCorrectedResponse) as CorrectedResponse;
+
+    if (!correctedResponse || typeof correctedResponse !== 'object') {
+        return correctedResponse;
+    }
+
+    // Convert acceptToBeContactedForHelp from 'yes'/'no' string to boolean
+    if (correctedResponse.acceptToBeContactedForHelp !== undefined) {
+        const booleishValue = _booleish(correctedResponse.acceptToBeContactedForHelp);
+        correctedResponse.acceptToBeContactedForHelp = booleishValue === null ? undefined : booleishValue;
+    }
+
+    // Also convert wouldLikeToParticipateInOtherSurveys if it exists
+    if (correctedResponse.wouldLikeToParticipateInOtherSurveys !== undefined) {
+        const booleishValue = _booleish(correctedResponse.wouldLikeToParticipateInOtherSurveys);
+        correctedResponse.wouldLikeToParticipateInOtherSurveys = booleishValue === null ? undefined : booleishValue;
+    }
+
+    // update the assignedDate attribute:
+    if (correctedResponse._assignedDay !== undefined) {
+        correctedResponse.assignedDate = correctedResponse._assignedDay;
+    }
+
+    // update the languages attribute:
+    if (correctedResponse._language && ['fr', 'en'].includes(correctedResponse._language)) {
+        correctedResponse._languages = [correctedResponse._language];
+    }
+
+    return correctedResponse;
+};

--- a/survey/src/admin/parsers/trip.parser.ts
+++ b/survey/src/admin/parsers/trip.parser.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { SurveyObjectParser } from 'evolution-backend/lib/services/audits/types';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { ExtendedTripAttributes } from 'evolution-common/lib/services/baseObjects/Trip';
+
+/**
+ * @param originalCorrectedTripAttributes - The trip attributes to parse
+ * @param correctedResponse - The corrected response
+ */
+export const parseTripAttributes: SurveyObjectParser<ExtendedTripAttributes, CorrectedResponse> = (
+    originalCorrectedTripAttributes: Readonly<ExtendedTripAttributes>,
+    correctedResponse: Readonly<CorrectedResponse>
+): ExtendedTripAttributes => {
+    const tripAttributes = _cloneDeep(originalCorrectedTripAttributes) as ExtendedTripAttributes;
+
+    if (!tripAttributes || typeof tripAttributes !== 'object') {
+        return tripAttributes;
+    }
+
+    // update start and end times from departure/arrival times:
+    if (tripAttributes.departureTime !== undefined) {
+        tripAttributes.startTime = tripAttributes.departureTime as number;
+    }
+    if (tripAttributes.arrivalTime !== undefined) {
+        tripAttributes.endTime = tripAttributes.arrivalTime as number;
+    }
+
+    if (!correctedResponse) {
+        return tripAttributes;
+    }
+
+    // update start and end dates from assigned date:
+    if (correctedResponse._assignedDay) {
+        tripAttributes.startDate = correctedResponse._assignedDay;
+        tripAttributes.endDate = correctedResponse._assignedDay;
+    }
+
+    return tripAttributes;
+};

--- a/survey/src/admin/parsers/visitedPlace.parser.ts
+++ b/survey/src/admin/parsers/visitedPlace.parser.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { ExtendedVisitedPlaceAttributes } from 'evolution-common/lib/services/baseObjects/VisitedPlace';
+import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { SurveyObjectParser } from 'evolution-backend/lib/services/audits/types';
+
+/**
+ * @param originalCorrectedVisitedPlaceAttributes - The visited place attributes to parse
+ * @param correctedResponse - The corrected response
+ */
+export const parseVisitedPlaceAttributes: SurveyObjectParser<ExtendedVisitedPlaceAttributes, CorrectedResponse> = (
+    originalCorrectedVisitedPlaceAttributes: Readonly<ExtendedVisitedPlaceAttributes>,
+    correctedResponse: Readonly<CorrectedResponse>
+): ExtendedVisitedPlaceAttributes => {
+    const visitedPlaceAttributes = _cloneDeep(
+        originalCorrectedVisitedPlaceAttributes
+    ) as ExtendedVisitedPlaceAttributes;
+
+    if (!visitedPlaceAttributes || typeof visitedPlaceAttributes !== 'object') {
+        return visitedPlaceAttributes;
+    }
+
+    // update start and end times from arrival/departure times:
+    if (visitedPlaceAttributes.arrivalTime !== undefined) {
+        visitedPlaceAttributes.startTime = Number(visitedPlaceAttributes.arrivalTime);
+    }
+    if (visitedPlaceAttributes.departureTime !== undefined) {
+        visitedPlaceAttributes.endTime = Number(visitedPlaceAttributes.departureTime);
+    }
+
+    if (!correctedResponse) {
+        return visitedPlaceAttributes;
+    }
+
+    // update start and end dates from assigned date:
+    if (correctedResponse._assignedDay !== undefined) {
+        visitedPlaceAttributes.startDate = correctedResponse._assignedDay;
+        visitedPlaceAttributes.endDate = correctedResponse._assignedDay;
+    }
+
+    return visitedPlaceAttributes;
+};

--- a/survey/src/admin/serverAdmin.ts
+++ b/survey/src/admin/serverAdmin.ts
@@ -15,13 +15,15 @@ import serverValidations from '../survey/server/serverValidations';
 import roleDefinitions from './server/roleDefinitions';
 import { setupMonitoringView } from './monitoring';
 import adminRoutes from './routes/admin.routes';
+import { surveyObjectParsers } from './parsers';
 
 // TODO Add validation list filter if necessary
 const configureServer = () => {
     setProjectConfig({
         serverUpdateCallbacks,
         serverValidations,
-        roleDefinitions
+        roleDefinitions,
+        surveyObjectParsers
     });
 
     adminRoutes(router); // Load API admin routes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic parsing/normalization for interviews, homes, trips and visited places; runtime parser mapping; added public config properties: countryCode, startDate, endDate, and mapAerialTilesUrl.

- **Tests**
  - Comprehensive unit and integration tests covering each parser, wiring, edge cases, concurrency, large-data and idempotence.

- **Documentation**
  - Coding rules updated: doc line prefix changed to -, prefer parametric tests, 4-space indentation, and referenced formatter configs.

- **Chores**
  - Parsers wired into server runtime/configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->