### PR TITLE
Implement survey end

### DIFF
--- a/.github/workflows/survey-ui-test.yml
+++ b/.github/workflows/survey-ui-test.yml
@@ -34,7 +34,7 @@ jobs:
         browser: [chrome, firefox] # We test on both Chrome and Firefox
     env:
       # FIXME: We should normally put NODE_ENV=production here, but some of the install and compile steps are not working well
-      PROJECT_CONFIG: ${{ github.workspace }}/survey/config.js
+      PROJECT_CONFIG: ${{ github.workspace }}/survey/configForCi.js
       PG_CONNECTION_STRING_PREFIX: postgres://testuser:testpassword@localhost:5432/
       PG_DATABASE_PRODUCTION: testdb_${{ matrix.browser }} # Use a different DB for each browser to avoid conflicts
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/survey/.eslintignore
+++ b/survey/.eslintignore
@@ -7,6 +7,7 @@ assets/documents
 **/__tests__
 jest.config.js
 config.js
+configForCi.js
 configVariantSpecific.js
 webpack.config.js
 webpack.admin.config.js

--- a/survey/configForCi.js
+++ b/survey/configForCi.js
@@ -1,0 +1,6 @@
+const config = require('./config');
+
+// Set survey end date to 3 days from now, to make sure the survey is always active in CI environments
+config.endDateTimeWithTimezoneOffset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+
+module.exports = config;

--- a/survey/locales/en/survey.yaml
+++ b/survey/locales/en/survey.yaml
@@ -490,3 +490,14 @@ thisPlace_workUsual: work
 theHome: home
 ConfirmDeleteLocation: Do you confirm that you want to remove this location?
 DeleteLocation: Delete this location
+surveyEnded:
+    thankYouMessage: >-
+        <p class="left"><span class="_strong">Thank you for your participation</span></p>
+        <p class="left">We sincerely thank you for taking the time to participate in the Origin-Destination Survey.</p><br/>
+        <p class="left">Thanks to your contribution, we now have essential data to better understand travel habits and support transportation planning that is sustainable and adapted to the needs of the population.</p><br/>
+        <p class="left"><span class="_strong">End of Data Collection</span></p>
+        <p class="left">The data collection period <span class="_strong">officially ended on December 16th</span>.</p>
+        <p class="left">The participation platform is now closed and it is no longer possible to submit new questionnaires.</p>
+        <p class="left">The information collected will be subject to in-depth analysis and will be used exclusively for the purposes intended as part of this survey, in accordance with confidentiality and data protection rules.</p><br/>
+        <p class="left">Thank you for your interest in the survey on people's mobility</p><br/>
+        <p class="left">For any additional information, we invite you to consult the page dedicated to the surveys: <a href="https://www.quebec.ca/transports/recherches-statistiques/planification/enquetes-origine-destination" target="_blank">About Origin-Destination Surveys | Government of Quebec</a></p>

--- a/survey/locales/fr/survey.yaml
+++ b/survey/locales/fr/survey.yaml
@@ -608,3 +608,14 @@ thisPlace_workUsual: le travail
 theHome: le domicile
 ConfirmDeleteLocation: Confirmez-vous que vous voulez retirer ce lieu?
 DeleteLocation: Supprimer ce lieu
+surveyEnded:
+    thankYouMessage: >-
+        <p class="left"><span class="_strong">Merci pour votre participation</span></p>
+        <p class="left">Nous vous remercions sincèrement d'avoir pris le temps de participer à l'enquête Origine-Destination.</p><br/>
+        <p class="left">Grâce à votre contribution, nous disposons désormais de données essentielles pour mieux comprendre les habitudes de déplacement et soutenir la planification des transports, durables et adaptées aux besoins de la population.</p><br/>
+        <p class="left"><span class="_strong">Clôture de la collecte</span></p>
+        <p class="left">La période de collecte des données est <span class="_strong">officiellement terminée depuis le 16 décembre</span>.</p>
+        <p class="left">La plateforme de participation est désormais fermée et il n'est plus possible de soumettre de nouveaux questionnaires.</p>
+        <p class="left">Les informations recueillies feront l'objet d'analyses approfondies et seront utilisées exclusivement aux fins prévues dans le cadre de cette enquête, dans le respect des règles de confidentialité et de protection des données.</p><br/>
+        <p class="left">Merci de l'intérêt que vous portez à l'enquête sur la mobilité des personnes</p><br/>
+        <p class="left">Pour toute information complémentaire, nous vous invitons à consulter la page dédiée aux enquêtes : <a href="https://www.quebec.ca/transports/recherches-statistiques/planification/enquetes-origine-destination" target="_blank">À propos des enquêtes origine-destination | Gouvernement du Québec</a></p>


### PR DESCRIPTION
Add the `surveyEnded.thankYouMessage` in the `survey.yaml`, as provided.

Let webpack generate both entry points for active and ended questionnaires.

Add a specific config file for CI to overwrite the survey end date to make sure the survey is always active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "survey ended" page with bilingual (English/French) thank-you messages and closure/privacy content.
  * CI test runs now use a temporary extended survey end date so the survey remains active during testing.

* **Chores**
  * Updated build configuration to produce separate bundles/pages for the survey and the ended page.
  * Adjusted CI and linting config to accommodate the new ended-page flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->