### PR TITLE
webpack: fix property name to pass the EV_VARIANT value

### DIFF
--- a/survey/webpack.admin.config.js
+++ b/survey/webpack.admin.config.js
@@ -48,7 +48,7 @@ module.exports = (env) => {
         htmlPages,
         customStylesFilePath: customStylesFilePath,
         projectLocalesFilePath: customLocalesFilePath,
-        extraEnvVars: {
+        extraEnvs: {
             EV_VARIANT: process.env.EV_VARIANT
         }
     });

--- a/survey/webpack.config.js
+++ b/survey/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = (env) => {
         htmlPages,
         customStylesFilePath: customStylesFilePath,
         projectLocalesFilePath: customLocalesFilePath,
-        extraEnvVars: {
+        extraEnvs: {
             EV_VARIANT: process.env.EV_VARIANT
         }
     });


### PR DESCRIPTION
The expected property in the webpack config getter is `extraEnvs`. Since webpack config files are simple javascript, no compile-time check was done and the wrong field name was used, the variant was thus not considered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal configuration parameter naming for improved code consistency across build configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/od_nationale_quebec/pull/473)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->