### PR TITLE
segments: use mode for transit access conditional

### DIFF
--- a/survey/src/survey/sections/segments/customWidgets.ts
+++ b/survey/src/survey/sections/segments/customWidgets.ts
@@ -108,6 +108,18 @@ const howToBusChoices = [
     }
 ];
 
+// These modes are transit modes that require to ask for the access mode to stop
+const transitModesForAccessMode = [
+    'transitBus',
+    'transitRRT',
+    'transitLRRT',
+    'transitRegionalRail',
+    'transitStreetCar',
+    'transitTaxi',
+    'transitFerry',
+    'train',
+    'intercityBus'
+];
 export const segmentHowToBus: WidgetConfig.InputRadioType = {
     type: 'question',
     path: 'howToBus',
@@ -128,7 +140,6 @@ export const segmentHowToBus: WidgetConfig.InputRadioType = {
     },
     conditional: function (interview, path) {
         const segment: any = getResponse(interview, path, null, '../');
-        const modePre = segment ? segment.modePre : null;
         const mode = segment ? segment.mode : null;
 
         const trip = odSurveyHelpers.getActiveTrip({ interview });
@@ -136,7 +147,7 @@ export const segmentHowToBus: WidgetConfig.InputRadioType = {
 
         const isFirst: boolean = segmentsArray[0] === segment;
 
-        return [modePre === 'transit' && isFirst && mode !== 'paratransit', modePre];
+        return [isFirst && transitModesForAccessMode.includes(mode), null];
     },
     validations: function (value, customValue, interview, path, customPath) {
         return [

--- a/survey/src/survey/sections/selectPerson/customWidgets.tsx
+++ b/survey/src/survey/sections/selectPerson/customWidgets.tsx
@@ -18,7 +18,7 @@ export const selectPerson: WidgetConfig.InputRadioType = {
     inputType: 'radio',
     datatype: 'string',
     containsHtml: true,
-    label: (t: TFunction) => t('selectPerson:_activePersonId'),
+    label: (t: TFunction) => t('selectPerson:selectPerson'),
     choices: function (interview) {
         const persons = odSurveyHelper.getPersons({ interview });
         let personsRandomSequence = getResponse(interview, '_personRandomSequence') as string[] | null;


### PR DESCRIPTION
fixes #502

Instead of the modePre, we use a mode list to get the modes that should be selected to ask for the transit access mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined access-mode questions for transit segments.
  - The bus guidance question now appears only for the first eligible transit segment, improving survey relevance and preventing it from appearing for unsupported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->